### PR TITLE
Add Python wrapper package

### DIFF
--- a/.github/workflows/ci-python-wrapper.yml
+++ b/.github/workflows/ci-python-wrapper.yml
@@ -1,0 +1,94 @@
+name: CI (Python wrapper)
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - symbolic_regression_py/**
+      - symbolic_regression/**
+      - dynamic_expressions/**
+      - .cargo/**
+      - Cargo.toml
+      - .github/workflows/ci-python-wrapper.yml
+  push:
+    branches:
+      - main
+    paths:
+      - symbolic_regression_py/**
+      - symbolic_regression/**
+      - dynamic_expressions/**
+      - .cargo/**
+      - Cargo.toml
+      - .github/workflows/ci-python-wrapper.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  python-wrapper:
+    name: Python wrapper
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.12", "3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install wrapper
+        run: uv pip install --system -e symbolic_regression_py
+
+      - name: Run Python wrapper tests
+        run: python -m unittest discover symbolic_regression_py/tests
+
+      - name: Build Python wrapper wheel
+        working-directory: symbolic_regression_py
+        run: uvx maturin build --out ../dist
+
+      - name: Test built wheel
+        working-directory: symbolic_regression_py
+        run: |
+          python -m venv "$RUNNER_TEMP/pysr-rust-backend-wheel"
+          . "$RUNNER_TEMP/pysr-rust-backend-wheel/bin/activate"
+          python -m pip install --upgrade pip
+          python -m pip install ../dist/*.whl
+          python -c "import numpy as np, symbolic_regression_rs; X=np.linspace(-1,1,24,dtype=np.float32).reshape(-1,1); y=X[:,0]; out=symbolic_regression_rs.search(X,y,options={'seed':0,'niterations':1,'populations':1,'population_size':16,'ncycles_per_iteration':20,'maxsize':10,'maxdepth':10,'deterministic':True,'progress':False},operators={2:['+','sub','*','/']},variable_names=['x0']); assert out['hall_of_fame']"
+
+      - name: Build source distribution
+        working-directory: symbolic_regression_py
+        run: uvx maturin sdist --out ../dist
+
+      - name: Test source distribution
+        working-directory: symbolic_regression_py
+        run: |
+          python -m venv "$RUNNER_TEMP/pysr-rust-backend-sdist"
+          . "$RUNNER_TEMP/pysr-rust-backend-sdist/bin/activate"
+          python -m pip install --upgrade pip
+          python -m pip install ../dist/*.tar.gz
+          python -c "import numpy as np, symbolic_regression_rs; X=np.linspace(-1,1,24,dtype=np.float32).reshape(-1,1); y=X[:,0]; out=symbolic_regression_rs.search(X,y,options={'seed':0,'niterations':1,'populations':1,'population_size':16,'ncycles_per_iteration':20,'maxsize':10,'maxdepth':10,'deterministic':True,'progress':False},operators={2:['+','sub','*','/']},variable_names=['x0']); assert out['hall_of_fame']"
+
+      - name: cargo check
+        run: cargo check -p symbolic_regression_rs_py
+
+      - name: cargo fmt --check
+        run: cargo fmt --check -p symbolic_regression_rs_py

--- a/.github/workflows/publish-python-wrapper.yml
+++ b/.github/workflows/publish-python-wrapper.yml
@@ -1,0 +1,179 @@
+name: Publish Python wrapper
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_ref:
+        description: Tag, branch, or commit SHA to publish
+        required: true
+        type: string
+      repository:
+        description: Package index to publish to
+        required: true
+        default: testpypi
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions:
+  contents: read
+
+jobs:
+  build-linux-wheels:
+    name: Build Linux wheels
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.publish_ref }}
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: symbolic_regression_py
+          command: build
+          args: --release -i python${{ matrix.python-version }} --out ../dist
+          manylinux: auto
+
+      - name: Test built wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -c "import glob, subprocess, sys; wheels=glob.glob('dist/*.whl'); assert len(wheels) == 1, wheels; subprocess.check_call([sys.executable, '-m', 'pip', 'install', wheels[0]])"
+          python -c "import numpy as np, symbolic_regression_rs; X=np.linspace(-1,1,24,dtype=np.float32).reshape(-1,1); y=X[:,0]; out=symbolic_regression_rs.search(X,y,options={'seed':0,'niterations':1,'populations':1,'population_size':16,'ncycles_per_iteration':20,'maxsize':10,'maxdepth':10,'deterministic':True,'progress':False},operators={2:['+','sub','*','/']},variable_names=['x0']); assert out['hall_of_fame']"
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: pysr-rust-backend-linux-wheel-${{ matrix.python-version }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  build-host-wheels:
+    name: Build ${{ matrix.os }} wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-13, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.publish_ref }}
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: symbolic_regression_py
+          command: build
+          args: --release --out ../dist
+          manylinux: off
+
+      - name: Test built wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -c "import glob, subprocess, sys; wheels=glob.glob('dist/*.whl'); assert len(wheels) == 1, wheels; subprocess.check_call([sys.executable, '-m', 'pip', 'install', wheels[0]])"
+          python -c "import numpy as np, symbolic_regression_rs; X=np.linspace(-1,1,24,dtype=np.float32).reshape(-1,1); y=X[:,0]; out=symbolic_regression_rs.search(X,y,options={'seed':0,'niterations':1,'populations':1,'population_size':16,'ncycles_per_iteration':20,'maxsize':10,'maxdepth':10,'deterministic':True,'progress':False},operators={2:['+','sub','*','/']},variable_names=['x0']); assert out['hall_of_fame']"
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: pysr-rust-backend-${{ matrix.os }}-wheel-${{ matrix.python-version }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.publish_ref }}
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build source distribution
+        working-directory: symbolic_regression_py
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "maturin>=1.8,<2"
+          maturin sdist --out ../dist
+
+      - name: Upload source distribution
+        uses: actions/upload-artifact@v4
+        with:
+          name: pysr-rust-backend-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish distributions
+    runs-on: ubuntu-latest
+    needs:
+      - build-linux-wheels
+      - build-host-wheels
+      - build-sdist
+    environment:
+      name: ${{ inputs.repository }}
+      url: ${{ inputs.repository == 'pypi' && 'https://pypi.org/p/pysr-rust-backend' || 'https://test.pypi.org/p/pysr-rust-backend' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pysr-rust-backend-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to TestPyPI
+        if: inputs.repository == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          verbose: true
+
+      - name: Publish to PyPI
+        if: inputs.repository == 'pypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,7 @@ Cargo.lock
 !web_ui/package-lock.json
 web_ui/src/generated/defaultCsv.ts
 **/.playwright-browsers/**
+**/__pycache__/
+**/.pytest_cache/
 !symbolic_regression_wasm/.cargo/
 !symbolic_regression_wasm/.cargo/**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "dynamic_expressions",
     "symbolic_regression",
+    "symbolic_regression_py",
     "symbolic_regression_wasm",
 ]
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ Try out a fully browser-based demo of WebAssembly-compiled symbolic regression [
 > This package is an **experiment**. The API is not stabilized, and you should expect large breaking changes in the syntax.
 > This library is not ready for use.
 
-This workspace contains three crates:
+This workspace contains three Rust crates and one Python extension package:
 
 | Crate | crates.io | CI |
 |---|---|---|
 | [`symbolic_regression`](./symbolic_regression) | [![crates.io](https://img.shields.io/crates/v/symbolic_regression)](https://crates.io/crates/symbolic_regression) | [![CI (symbolic_regression)](https://github.com/astro-automata/symbolic_regression.rs/actions/workflows/ci-symbolic-regression.yml/badge.svg?branch=main)](https://github.com/astro-automata/symbolic_regression.rs/actions/workflows/ci-symbolic-regression.yml) |
 | [`dynamic_expressions`](./dynamic_expressions) | [![crates.io](https://img.shields.io/crates/v/dynamic_expressions)](https://crates.io/crates/dynamic_expressions) | [![CI (dynamic_expressions)](https://github.com/astro-automata/symbolic_regression.rs/actions/workflows/ci-dynamic-expressions.yml/badge.svg?branch=main)](https://github.com/astro-automata/symbolic_regression.rs/actions/workflows/ci-dynamic-expressions.yml) |
 | [`symbolic_regression_wasm`](./symbolic_regression_wasm) | [![crates.io](https://img.shields.io/crates/v/symbolic_regression_wasm)](https://crates.io/crates/symbolic_regression_wasm) | [![CI (Web UI)](https://github.com/astro-automata/symbolic_regression.rs/actions/workflows/ci-web.yml/badge.svg?branch=main)](https://github.com/astro-automata/symbolic_regression.rs/actions/workflows/ci-web.yml) |
+| [`symbolic_regression_py`](./symbolic_regression_py) | `pysr-rust-backend` package draft | [![CI (Python wrapper)](https://github.com/astroautomata/symbolic_regression.rs/actions/workflows/ci-python-wrapper.yml/badge.svg?branch=main)](https://github.com/astroautomata/symbolic_regression.rs/actions/workflows/ci-python-wrapper.yml) |
 
 ## Low-level API
 

--- a/symbolic_regression_py/Cargo.toml
+++ b/symbolic_regression_py/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "symbolic_regression_rs_py"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Experimental Rust backend package for PySR."
+homepage = "https://github.com/astroautomata/symbolic_regression.rs"
+repository = "https://github.com/astroautomata/symbolic_regression.rs"
+publish = false
+
+[lib]
+name = "symbolic_regression_rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+dynamic_expressions = { version = "0.10.1", path = "../dynamic_expressions", default-features = false }
+ndarray = "0.17"
+num-traits = "0.2"
+numpy = "0.29"
+pyo3 = { version = "0.29", features = ["extension-module"] }
+rayon = "1"
+symbolic_regression = { version = "0.12.2", path = "../symbolic_regression", default-features = false }

--- a/symbolic_regression_py/README.md
+++ b/symbolic_regression_py/README.md
@@ -1,0 +1,94 @@
+# pysr-rust-backend
+
+Experimental Rust backend package for PySR.
+
+The distribution name is `pysr-rust-backend`; it installs the
+`symbolic_regression_rs` import module consumed by PySR's optional Rust backend.
+It deliberately exposes a small wire contract first: Python arrays and plain
+dictionaries in, plain dictionaries out.
+
+> This package is experimental and should be treated as a PySR backend boundary,
+> not a stable standalone Python API, while the Rust engine API is still
+> stabilizing.
+
+## Install For Development
+
+From the workspace root:
+
+```bash
+uv pip install --python /path/to/python -e symbolic_regression_py
+```
+
+Or, from this directory:
+
+```bash
+python -m pip install -e .
+```
+
+## Python API
+
+```python
+import numpy as np
+import symbolic_regression_rs
+
+X = np.linspace(-1, 1, 64, dtype=np.float32).reshape(-1, 1)
+y = X[:, 0]
+
+out = symbolic_regression_rs.search(
+    X,
+    y,
+    options={
+        "seed": 0,
+        "niterations": 1,
+        "populations": 1,
+        "population_size": 16,
+        "ncycles_per_iteration": 20,
+        "deterministic": True,
+        "progress": False,
+    },
+    operators={2: ["+", "sub", "*"]},
+    variable_names=["x0"],
+)
+
+print(out["hall_of_fame"])
+```
+
+The return value is a dictionary:
+
+```python
+{
+    "backend_version": "0.1.0",
+    "hall_of_fame": [
+        {"complexity": 1, "loss": 0.0, "equation": "x0"},
+    ],
+}
+```
+
+## Current Limits
+
+- Dense NumPy arrays only.
+- `float32` and `float64` only.
+- Single-output regression only.
+- Builtin Rust operators only, with operator arities validated from the
+  `operators={arity: [names]}` mapping.
+- Unknown or unsupported option keys raise `ValueError`.
+- No sample weights, non-MSE losses, per-variable/per-operator complexities,
+  constraints, nested constraints, Python callbacks, custom losses, custom
+  operators, GPU, warm start, or richer PySR output yet.
+
+## Test
+
+Install the package first, then run:
+
+```bash
+python -m unittest discover symbolic_regression_py/tests
+cargo check -p symbolic_regression_rs_py
+cargo test
+```
+
+## Publish
+
+The repository includes a manual `Publish Python wrapper` GitHub Actions
+workflow. It builds Linux, Windows, and macOS wheels for Python 3.9 through
+3.13 plus a source distribution from a selected ref, uploads the artifacts, and
+publishes to TestPyPI or PyPI through trusted publishing.

--- a/symbolic_regression_py/pyproject.toml
+++ b/symbolic_regression_py/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["maturin>=1.8,<2"]
+build-backend = "maturin"
+
+[project]
+name = "pysr-rust-backend"
+version = "0.1.0"
+description = "Experimental Rust backend package for PySR."
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = ["numpy>=1.23"]
+license = { text = "Apache-2.0" }
+keywords = ["symbolic-regression", "genetic-programming", "pysr", "rust-backend"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Rust",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+[project.urls]
+Homepage = "https://github.com/astroautomata/symbolic_regression.rs"
+Repository = "https://github.com/astroautomata/symbolic_regression.rs"
+Issues = "https://github.com/astroautomata/symbolic_regression.rs/issues"
+
+[tool.maturin]
+module-name = "symbolic_regression_rs"
+features = ["pyo3/extension-module"]

--- a/symbolic_regression_py/src/lib.rs
+++ b/symbolic_regression_py/src/lib.rs
@@ -1,0 +1,432 @@
+use std::ops::AddAssign;
+
+use dynamic_expressions::Operators;
+use dynamic_expressions::operator_enum::presets::{BuiltinOpsF32, BuiltinOpsF64};
+use dynamic_expressions::strings::{StringTreeOptions, string_tree};
+use ndarray::{Array1, Array2};
+use num_traits::{Float, FromPrimitive, ToPrimitive};
+use numpy::{Element, PyReadonlyArray1, PyReadonlyArray2};
+use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyModule};
+use symbolic_regression::{Dataset, EarlyStop, Options, OutputStyle, equation_search};
+
+const MAX_ARITY: usize = 3;
+const SUPPORTED_OPTIONS: &[&str] = &[
+    "seed",
+    "niterations",
+    "populations",
+    "population_size",
+    "ncycles_per_iteration",
+    "batch_size",
+    "complexity_of_constants",
+    "complexity_of_variables",
+    "maxsize",
+    "maxdepth",
+    "warmup_maxsize_by",
+    "parsimony",
+    "adaptive_parsimony_scaling",
+    "crossover_probability",
+    "perturbation_factor",
+    "probability_negate_constant",
+    "tournament_selection_n",
+    "tournament_selection_p",
+    "alpha",
+    "optimizer_nrestarts",
+    "optimizer_probability",
+    "optimizer_iterations",
+    "optimizer_f_calls_limit",
+    "fraction_replaced",
+    "fraction_replaced_hof",
+    "topn",
+    "print_precision",
+    "max_evals",
+    "timeout_in_seconds",
+    "use_frequency",
+    "use_frequency_in_tournament",
+    "skip_mutation_failures",
+    "annealing",
+    "should_optimize_constants",
+    "migration",
+    "hof_migration",
+    "progress",
+    "should_simplify",
+    "batching",
+    "deterministic",
+    "parallelism",
+    "early_stop_condition",
+    "mutation_weights",
+];
+const SUPPORTED_MUTATION_WEIGHTS: &[&str] = &[
+    "mutate_constant",
+    "mutate_operator",
+    "mutate_feature",
+    "swap_operands",
+    "rotate_tree",
+    "add_node",
+    "insert_node",
+    "delete_node",
+    "simplify",
+    "randomize",
+    "do_nothing",
+    "optimize",
+    "form_connection",
+    "break_connection",
+];
+
+#[pyfunction]
+#[pyo3(signature = (x, y, *, options, operators, variable_names))]
+fn search(
+    py: Python<'_>,
+    x: &Bound<'_, PyAny>,
+    y: &Bound<'_, PyAny>,
+    options: &Bound<'_, PyDict>,
+    operators: &Bound<'_, PyDict>,
+    variable_names: Vec<String>,
+) -> PyResult<Py<PyAny>> {
+    if let (Ok(x), Ok(y)) = (
+        x.extract::<PyReadonlyArray2<'_, f32>>(),
+        y.extract::<PyReadonlyArray1<'_, f32>>(),
+    ) {
+        return run_search::<f32, BuiltinOpsF32>(py, x, y, options, operators, variable_names);
+    }
+
+    if let (Ok(x), Ok(y)) = (
+        x.extract::<PyReadonlyArray2<'_, f64>>(),
+        y.extract::<PyReadonlyArray1<'_, f64>>(),
+    ) {
+        return run_search::<f64, BuiltinOpsF64>(py, x, y, options, operators, variable_names);
+    }
+
+    Err(PyTypeError::new_err(
+        "X and y must be NumPy arrays with matching float32 or float64 dtypes",
+    ))
+}
+
+fn run_search<T, Ops>(
+    py: Python<'_>,
+    x: PyReadonlyArray2<'_, T>,
+    y: PyReadonlyArray1<'_, T>,
+    options_dict: &Bound<'_, PyDict>,
+    operators_dict: &Bound<'_, PyDict>,
+    variable_names: Vec<String>,
+) -> PyResult<Py<PyAny>>
+where
+    T: Float + AddAssign + FromPrimitive + ToPrimitive + std::fmt::Display + Send + Sync + Element + 'static,
+    Ops: dynamic_expressions::OperatorSet<T = T> + Send + Sync,
+{
+    let dataset = build_dataset(x, y, variable_names)?;
+    let operator_names = extract_operator_names(operators_dict)?;
+    let operators = Operators::<MAX_ARITY>::from_names::<Ops, _>(operator_names.iter().map(String::as_str))
+        .map_err(|err| PyValueError::new_err(format!("invalid operator selection: {err}")))?;
+
+    let mut options = Options::<T, MAX_ARITY> {
+        operators,
+        ..Default::default()
+    };
+    apply_options(&mut options, options_dict)?;
+    let parallelism = extract_parallelism(options_dict)?;
+
+    let result = if parallelism.as_deref() == Some("serial") {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .map_err(|err| PyRuntimeError::new_err(format!("failed to create serial thread pool: {err}")))?;
+        py.detach(|| pool.install(|| equation_search::<T, Ops, MAX_ARITY>(&dataset, &options)))
+    } else {
+        py.detach(|| equation_search::<T, Ops, MAX_ARITY>(&dataset, &options))
+    };
+
+    let rows = PyList::empty(py);
+    for member in result.hall_of_fame.pareto_front() {
+        let row = PyDict::new(py);
+        row.set_item("complexity", member.complexity)?;
+        row.set_item(
+            "loss",
+            member
+                .loss
+                .to_f64()
+                .ok_or_else(|| PyRuntimeError::new_err("failed to convert loss to float"))?,
+        )?;
+        row.set_item(
+            "equation",
+            string_tree(
+                &member.expr,
+                StringTreeOptions {
+                    variable_names: Some(dataset.variable_names.as_slice()),
+                    pretty: false,
+                    print_precision: Some(options.print_precision),
+                },
+            ),
+        )?;
+        rows.append(row)?;
+    }
+
+    let out = PyDict::new(py);
+    out.set_item("backend_version", env!("CARGO_PKG_VERSION"))?;
+    out.set_item("hall_of_fame", rows)?;
+    Ok(out.into_any().unbind())
+}
+
+fn build_dataset<T>(
+    x: PyReadonlyArray2<'_, T>,
+    y: PyReadonlyArray1<'_, T>,
+    variable_names: Vec<String>,
+) -> PyResult<Dataset<T>>
+where
+    T: Float + FromPrimitive + Element,
+{
+    let x_view = x.as_array();
+    let y_view = y.as_array();
+    let shape = x_view.shape();
+    let n_rows = shape[0];
+    let n_features = shape[1];
+
+    if y_view.len() != n_rows {
+        return Err(PyValueError::new_err(format!(
+            "X has {n_rows} rows but y has {} elements",
+            y_view.len()
+        )));
+    }
+    if !variable_names.is_empty() && variable_names.len() != n_features {
+        return Err(PyValueError::new_err(format!(
+            "expected {n_features} variable names, got {}",
+            variable_names.len()
+        )));
+    }
+
+    let mut rust_x = Array2::<T>::zeros((n_features, n_rows));
+    for row in 0..n_rows {
+        for feature in 0..n_features {
+            rust_x[(feature, row)] = x_view[(row, feature)];
+        }
+    }
+    let rust_y = Array1::from_iter(y_view.iter().copied());
+
+    Ok(Dataset::with_weights_and_names(rust_x, rust_y, None, variable_names))
+}
+
+fn extract_operator_names(operators: &Bound<'_, PyDict>) -> PyResult<Vec<String>> {
+    let mut out = Vec::new();
+    for (arity_obj, item) in operators.iter() {
+        let arity: usize = arity_obj.extract()?;
+        if arity > MAX_ARITY {
+            return Err(PyValueError::new_err(format!(
+                "operators only support arities up to {MAX_ARITY}, got {arity}"
+            )));
+        }
+        let names: Vec<String> = item.extract()?;
+        for name in &names {
+            let expected_arity = operator_arity(name)
+                .ok_or_else(|| PyValueError::new_err(format!("unsupported builtin operator {name:?}")))?;
+            if arity != expected_arity {
+                return Err(PyValueError::new_err(format!(
+                    "operator {name:?} has arity {expected_arity} but was provided under arity {arity}"
+                )));
+            }
+        }
+        out.extend(names);
+    }
+    if out.is_empty() {
+        return Err(PyValueError::new_err("at least one operator is required"));
+    }
+    Ok(out)
+}
+
+fn operator_arity(name: &str) -> Option<usize> {
+    match name {
+        "sin" | "cos" | "tan" | "exp" | "log" | "sqrt" | "abs" | "abs2" => Some(1),
+        "+" | "*" | "/" | "sub" => Some(2),
+        _ => None,
+    }
+}
+
+fn extract_parallelism(options: &Bound<'_, PyDict>) -> PyResult<Option<String>> {
+    let Some(value) = options.get_item("parallelism")? else {
+        return Ok(None);
+    };
+    let parallelism: String = value.extract()?;
+    match parallelism.as_str() {
+        "serial" | "multithreading" => Ok(Some(parallelism)),
+        other => Err(PyValueError::new_err(format!(
+            "parallelism must be 'serial' or 'multithreading', got {other:?}"
+        ))),
+    }
+}
+
+fn apply_options<T: Float + FromPrimitive + Send + Sync + 'static>(
+    options: &mut Options<T, MAX_ARITY>,
+    source: &Bound<'_, PyDict>,
+) -> PyResult<()> {
+    options.output_style = OutputStyle::Plain;
+    validate_known_keys(source, SUPPORTED_OPTIONS, "options")?;
+
+    assign_u64(source, "seed", &mut options.seed)?;
+    assign_usize(source, "niterations", &mut options.niterations)?;
+    assign_usize(source, "populations", &mut options.populations)?;
+    assign_usize(source, "population_size", &mut options.population_size)?;
+    assign_usize(source, "ncycles_per_iteration", &mut options.ncycles_per_iteration)?;
+    assign_usize(source, "batch_size", &mut options.batch_size)?;
+    assign_u16(source, "complexity_of_constants", &mut options.complexity_of_constants)?;
+    assign_u16(source, "complexity_of_variables", &mut options.complexity_of_variables)?;
+    assign_usize(source, "maxsize", &mut options.maxsize)?;
+    assign_usize(source, "maxdepth", &mut options.maxdepth)?;
+    assign_f32(source, "warmup_maxsize_by", &mut options.warmup_maxsize_by)?;
+    assign_f64(source, "parsimony", &mut options.parsimony)?;
+    assign_f64(
+        source,
+        "adaptive_parsimony_scaling",
+        &mut options.adaptive_parsimony_scaling,
+    )?;
+    assign_f64(source, "crossover_probability", &mut options.crossover_probability)?;
+    assign_f64(source, "perturbation_factor", &mut options.perturbation_factor)?;
+    assign_f64(
+        source,
+        "probability_negate_constant",
+        &mut options.probability_negate_constant,
+    )?;
+    assign_usize(source, "tournament_selection_n", &mut options.tournament_selection_n)?;
+    assign_f32(source, "tournament_selection_p", &mut options.tournament_selection_p)?;
+    assign_f64(source, "alpha", &mut options.alpha)?;
+    assign_usize(source, "optimizer_nrestarts", &mut options.optimizer_nrestarts)?;
+    assign_f64(source, "optimizer_probability", &mut options.optimizer_probability)?;
+    assign_usize(source, "optimizer_iterations", &mut options.optimizer_iterations)?;
+    assign_usize(source, "optimizer_f_calls_limit", &mut options.optimizer_f_calls_limit)?;
+    assign_f64(source, "fraction_replaced", &mut options.fraction_replaced)?;
+    assign_f64(source, "fraction_replaced_hof", &mut options.fraction_replaced_hof)?;
+    assign_usize(source, "topn", &mut options.topn)?;
+    assign_usize(source, "print_precision", &mut options.print_precision)?;
+    assign_u64(source, "max_evals", &mut options.max_evals)?;
+    assign_f64(source, "timeout_in_seconds", &mut options.timeout_in_seconds)?;
+
+    assign_bool(source, "use_frequency", &mut options.use_frequency)?;
+    assign_bool(
+        source,
+        "use_frequency_in_tournament",
+        &mut options.use_frequency_in_tournament,
+    )?;
+    assign_bool(source, "skip_mutation_failures", &mut options.skip_mutation_failures)?;
+    assign_bool(source, "annealing", &mut options.annealing)?;
+    assign_bool(
+        source,
+        "should_optimize_constants",
+        &mut options.should_optimize_constants,
+    )?;
+    assign_bool(source, "migration", &mut options.migration)?;
+    assign_bool(source, "hof_migration", &mut options.hof_migration)?;
+    assign_bool(source, "progress", &mut options.progress)?;
+    assign_bool(source, "should_simplify", &mut options.should_simplify)?;
+    assign_bool(source, "batching", &mut options.batching)?;
+    assign_bool(source, "deterministic", &mut options.deterministic)?;
+
+    if let Some(value) = source.get_item("early_stop_condition")? {
+        let threshold_f64: f64 = value.extract()?;
+        let threshold = T::from_f64(threshold_f64)
+            .ok_or_else(|| PyValueError::new_err("early_stop_condition must be representable as backend float"))?;
+        options.early_stop_condition = Some(EarlyStop::below(threshold));
+    }
+
+    if let Some(value) = source.get_item("mutation_weights")? {
+        let weights = value.cast::<PyDict>()?;
+        validate_known_keys(weights, SUPPORTED_MUTATION_WEIGHTS, "mutation_weights")?;
+        assign_f64(
+            weights,
+            "mutate_constant",
+            &mut options.mutation_weights.mutate_constant,
+        )?;
+        assign_f64(
+            weights,
+            "mutate_operator",
+            &mut options.mutation_weights.mutate_operator,
+        )?;
+        assign_f64(weights, "mutate_feature", &mut options.mutation_weights.mutate_feature)?;
+        assign_f64(weights, "swap_operands", &mut options.mutation_weights.swap_operands)?;
+        assign_f64(weights, "rotate_tree", &mut options.mutation_weights.rotate_tree)?;
+        assign_f64(weights, "add_node", &mut options.mutation_weights.add_node)?;
+        assign_f64(weights, "insert_node", &mut options.mutation_weights.insert_node)?;
+        assign_f64(weights, "delete_node", &mut options.mutation_weights.delete_node)?;
+        assign_f64(weights, "simplify", &mut options.mutation_weights.simplify)?;
+        assign_f64(weights, "randomize", &mut options.mutation_weights.randomize)?;
+        assign_f64(weights, "do_nothing", &mut options.mutation_weights.do_nothing)?;
+        assign_f64(weights, "optimize", &mut options.mutation_weights.optimize)?;
+        assign_f64(
+            weights,
+            "form_connection",
+            &mut options.mutation_weights.form_connection,
+        )?;
+        assign_f64(
+            weights,
+            "break_connection",
+            &mut options.mutation_weights.break_connection,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn validate_known_keys(source: &Bound<'_, PyDict>, allowed: &[&str], context: &str) -> PyResult<()> {
+    let mut unknown = Vec::new();
+    for key in source.keys() {
+        let key: String = key.extract()?;
+        if !allowed.contains(&key.as_str()) {
+            unknown.push(key);
+        }
+    }
+    if unknown.is_empty() {
+        return Ok(());
+    }
+    unknown.sort();
+    Err(PyValueError::new_err(format!(
+        "unsupported or unknown {context}: {}",
+        unknown.join(", ")
+    )))
+}
+
+fn assign_usize(source: &Bound<'_, PyDict>, name: &str, target: &mut usize) -> PyResult<()> {
+    if let Some(value) = source.get_item(name)? {
+        *target = value.extract()?;
+    }
+    Ok(())
+}
+
+fn assign_u16(source: &Bound<'_, PyDict>, name: &str, target: &mut u16) -> PyResult<()> {
+    if let Some(value) = source.get_item(name)? {
+        *target = value.extract()?;
+    }
+    Ok(())
+}
+
+fn assign_u64(source: &Bound<'_, PyDict>, name: &str, target: &mut u64) -> PyResult<()> {
+    if let Some(value) = source.get_item(name)? {
+        *target = value.extract()?;
+    }
+    Ok(())
+}
+
+fn assign_f32(source: &Bound<'_, PyDict>, name: &str, target: &mut f32) -> PyResult<()> {
+    if let Some(value) = source.get_item(name)? {
+        *target = value.extract()?;
+    }
+    Ok(())
+}
+
+fn assign_f64(source: &Bound<'_, PyDict>, name: &str, target: &mut f64) -> PyResult<()> {
+    if let Some(value) = source.get_item(name)? {
+        *target = value.extract()?;
+    }
+    Ok(())
+}
+
+fn assign_bool(source: &Bound<'_, PyDict>, name: &str, target: &mut bool) -> PyResult<()> {
+    if let Some(value) = source.get_item(name)? {
+        *target = value.extract()?;
+    }
+    Ok(())
+}
+
+#[pymodule]
+fn symbolic_regression_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add_function(wrap_pyfunction!(search, m)?)?;
+    Ok(())
+}

--- a/symbolic_regression_py/tests/test_search.py
+++ b/symbolic_regression_py/tests/test_search.py
@@ -1,0 +1,128 @@
+import unittest
+
+import numpy as np
+import symbolic_regression_rs
+
+
+class TestSearch(unittest.TestCase):
+    def _search(self, X, y, *, options=None, operators=None, variable_names=None):
+        search_options = {
+            "seed": 0,
+            "niterations": 1,
+            "populations": 1,
+            "population_size": 16,
+            "ncycles_per_iteration": 20,
+            "maxsize": 10,
+            "maxdepth": 10,
+            "deterministic": True,
+            "progress": False,
+        }
+        if options is not None:
+            search_options.update(options)
+        return symbolic_regression_rs.search(
+            X,
+            y,
+            options=search_options,
+            operators=operators or {2: ["+", "sub", "*"]},
+            variable_names=variable_names or ["x0"],
+        )
+
+    def test_search_float32_returns_hall_of_fame(self):
+        X = np.linspace(-1, 1, 32, dtype=np.float32).reshape(-1, 1)
+        y = X[:, 0]
+
+        out = self._search(X, y)
+
+        self.assertEqual(out["backend_version"], symbolic_regression_rs.__version__)
+        self.assertTrue(out["hall_of_fame"])
+        best_loss = min(row["loss"] for row in out["hall_of_fame"])
+        self.assertLessEqual(best_loss, 1e-6)
+        for row in out["hall_of_fame"]:
+            self.assertIsInstance(row["complexity"], int)
+            self.assertIsInstance(row["loss"], float)
+            self.assertIsInstance(row["equation"], str)
+
+    def test_search_float64_returns_hall_of_fame(self):
+        X = np.linspace(-1, 1, 24, dtype=np.float64).reshape(-1, 1)
+        y = X[:, 0]
+
+        out = self._search(X, y)
+
+        self.assertTrue(out["hall_of_fame"])
+
+    def test_search_rejects_mismatched_rows(self):
+        X = np.ones((4, 1), dtype=np.float32)
+        y = np.ones(3, dtype=np.float32)
+
+        with self.assertRaisesRegex(ValueError, "X has 4 rows"):
+            self._search(X, y)
+
+    def test_search_rejects_bad_variable_names_length(self):
+        X = np.ones((4, 2), dtype=np.float32)
+        y = np.ones(4, dtype=np.float32)
+
+        with self.assertRaisesRegex(ValueError, "expected 2 variable names"):
+            self._search(X, y, variable_names=["x0"])
+
+    def test_search_rejects_unknown_operator(self):
+        X = np.ones((4, 1), dtype=np.float32)
+        y = np.ones(4, dtype=np.float32)
+
+        with self.assertRaisesRegex(ValueError, "unsupported builtin operator"):
+            self._search(X, y, operators={1: ["not_an_operator"]})
+
+    def test_search_rejects_operator_under_wrong_arity(self):
+        X = np.ones((4, 1), dtype=np.float32)
+        y = np.ones(4, dtype=np.float32)
+
+        with self.assertRaisesRegex(ValueError, "has arity 2"):
+            self._search(X, y, operators={1: ["+"]})
+
+    def test_search_accepts_pysr_division_token(self):
+        X = np.linspace(1, 2, 16, dtype=np.float32).reshape(-1, 1)
+        y = X[:, 0]
+
+        out = self._search(X, y, operators={2: ["/"]})
+
+        self.assertTrue(out["hall_of_fame"])
+
+    def test_search_accepts_serial_parallelism(self):
+        X = np.linspace(-1, 1, 24, dtype=np.float32).reshape(-1, 1)
+        y = X[:, 0]
+
+        out = self._search(X, y, options={"parallelism": "serial"})
+
+        self.assertTrue(out["hall_of_fame"])
+
+    def test_search_rejects_unknown_parallelism(self):
+        X = np.ones((4, 1), dtype=np.float32)
+        y = np.ones(4, dtype=np.float32)
+
+        with self.assertRaisesRegex(ValueError, "parallelism"):
+            self._search(X, y, options={"parallelism": "multiprocessing"})
+
+    def test_search_rejects_unknown_option(self):
+        X = np.ones((4, 1), dtype=np.float32)
+        y = np.ones(4, dtype=np.float32)
+
+        with self.assertRaisesRegex(ValueError, "unsupported or unknown options"):
+            self._search(X, y, options={"not_a_real_option": 1})
+
+    def test_search_rejects_unknown_mutation_weight(self):
+        X = np.ones((4, 1), dtype=np.float32)
+        y = np.ones(4, dtype=np.float32)
+
+        with self.assertRaisesRegex(ValueError, "unsupported or unknown mutation_weights"):
+            self._search(X, y, options={"mutation_weights": {"not_a_real_weight": 1.0}})
+
+    def test_search_accepts_nondefault_seed(self):
+        X = np.linspace(-1, 1, 24, dtype=np.float32).reshape(-1, 1)
+        y = X[:, 0]
+
+        out = self._search(X, y, options={"seed": 123})
+
+        self.assertTrue(out["hall_of_fame"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a `symbolic_regression_py` PyO3/maturin package exposing `symbolic_regression_rs.search(...)`.
- Rename the Python distribution to `pysr-rust-backend` while keeping the import module `symbolic_regression_rs` for the PySR backend boundary.
- Keep the Python boundary deliberately narrow: dense float32/float64 NumPy arrays plus plain Python dict/list options in, hall-of-fame dict output out.
- Add wrapper CI that installs, tests, builds, and smoke-tests wheel and sdist artifacts.
- Add a manual publish workflow for TestPyPI/PyPI wheels and sdist, with per-wheel smoke tests before upload.
- Document the wrapper package in the workspace README and package README.

## Context

This is the wrapper-first step for exposing the Rust engine to PySR as discussed in https://github.com/MilesCranmer/PySR/discussions/1197. Once this package is accepted and published, PySR can depend on a normal `pysr-rust-backend` package from its optional Rust extra instead of vendoring the Rust workspace.

## Follow-up to review comments

- Propagate the `seed` option into `Options::seed`.
- Reject unknown option keys and unknown nested `mutation_weights` keys instead of silently ignoring them.
- Validate operator arity from the `operators={arity: [names]}` mapping.
- Document the wrapper as an experimental PySR backend wire package rather than a stable standalone Python API.
- Document unsupported feature coverage explicitly.
- Smoke-test publish workflow wheels after build and before upload.

## Related PR

- Companion PySR adapter PR: https://github.com/astroautomata/PySR/pull/1242
- This PR provides the installable Python package consumed by that PySR PR's experimental Rust backend adapter.

## Validation

- `cargo fmt --check -p symbolic_regression_rs_py`
- `cargo check -p symbolic_regression_rs_py`
- `cargo test`
- `python -m pytest symbolic_regression_py/tests -q`: 12 passed
- Parsed `.github/workflows/ci-python-wrapper.yml` and `.github/workflows/publish-python-wrapper.yml` with PyYAML