### PR TITLE
Add native delay expression support

### DIFF
--- a/dynamic_expressions/src/compile.rs
+++ b/dynamic_expressions/src/compile.rs
@@ -57,6 +57,10 @@ pub fn compile_plan<const D: usize>(nodes: &[PNode], n_features: usize, n_consts
                 assert!(feature < n_features_u16, "Var index out of bounds");
                 stack.push(Src::Var(feature));
             }
+            PNode::Delay { feature, offset } => {
+                assert!(feature < n_features_u16, "Delay feature index out of bounds");
+                stack.push(Src::Delay { feature, offset });
+            }
             PNode::Const { idx } => {
                 assert!(idx < n_consts_u16, "Const index out of bounds");
                 stack.push(Src::Const(idx));

--- a/dynamic_expressions/src/dispatch.rs
+++ b/dynamic_expressions/src/dispatch.rs
@@ -5,6 +5,7 @@ use crate::evaluate::EvalOptions;
 #[derive(Copy, Clone, Debug)]
 pub enum SrcRef<'a, T> {
     Slice(&'a [T]),
+    ShiftedSlice { slice: &'a [T], offset: usize },
     Const(T),
 }
 

--- a/dynamic_expressions/src/evaluate.rs
+++ b/dynamic_expressions/src/evaluate.rs
@@ -95,6 +95,14 @@ pub(crate) fn resolve_val_src<'a, T: Float>(
             let end = start + n_rows;
             SrcRef::Slice(&x_columns[start..end])
         }
+        Src::Delay { feature, offset } => {
+            let start = feature as usize * n_rows;
+            let end = start + n_rows;
+            SrcRef::ShiftedSlice {
+                slice: &x_columns[start..end],
+                offset: offset as usize,
+            }
+        }
         Src::Const(c) => SrcRef::Const(consts[c as usize]),
         Src::Slot(s) => {
             let slot = s as usize;
@@ -126,6 +134,33 @@ where
     let mut out = vec![T::zero(); n_rows];
     let complete = eval_tree_array_into::<T, Ops, D>(&mut out, expr, x_columns, &mut ctx, opts);
     (out, complete)
+}
+
+pub fn delay_validity_mask(nodes: &[crate::node::PNode], n_rows: usize, sequence_ids: Option<&[usize]>) -> Vec<bool> {
+    let mut out = vec![false; n_rows];
+    delay_validity_mask_into(&mut out, nodes, sequence_ids);
+    out
+}
+
+pub fn delay_validity_mask_into(out: &mut [bool], nodes: &[crate::node::PNode], sequence_ids: Option<&[usize]>) {
+    let n_rows = out.len();
+    if let Some(ids) = sequence_ids {
+        assert_eq!(ids.len(), n_rows);
+    }
+
+    let max_delay = crate::node_utils::max_delay(nodes);
+    if max_delay == 0 {
+        out.fill(true);
+        return;
+    }
+
+    for (row, dst) in out.iter_mut().enumerate() {
+        *dst = if row < max_delay {
+            false
+        } else {
+            sequence_ids.map_or(true, |ids| ids[row] == ids[row - max_delay])
+        };
+    }
 }
 
 pub fn eval_plan_array_into<T, Ops, const D: usize>(
@@ -186,6 +221,14 @@ where
         Src::Var(f) => {
             out.copy_from_slice(&x_data[f as usize * n_rows..(f as usize + 1) * n_rows]);
         }
+        Src::Delay { feature, offset } => {
+            let start = feature as usize * n_rows;
+            let source = &x_data[start..start + n_rows];
+            let offset = offset as usize;
+            for (row, dst) in out.iter_mut().enumerate() {
+                *dst = source[row.saturating_sub(offset)];
+            }
+        }
         Src::Const(c) => {
             let v = expr.consts[c as usize];
             if opts.check_finite && !v.is_finite() {
@@ -238,6 +281,7 @@ pub mod kernels {
     fn __src_val<T: Float>(src: SrcRef<'_, T>, row: usize) -> T {
         match src {
             SrcRef::Slice(s) => s[row],
+            SrcRef::ShiftedSlice { slice, offset } => slice[row.saturating_sub(offset)],
             SrcRef::Const(c) => c,
         }
     }
@@ -254,6 +298,7 @@ pub mod kernels {
     #[derive(Clone, Copy)]
     enum ArgView<'a, T> {
         Slice(&'a [T]),
+        ShiftedSlice { slice: &'a [T], offset: usize },
         Const(T),
     }
 
@@ -261,6 +306,7 @@ pub mod kernels {
         fn from(value: SrcRef<'a, T>) -> Self {
             match value {
                 SrcRef::Slice(s) => Self::Slice(s),
+                SrcRef::ShiftedSlice { slice, offset } => Self::ShiftedSlice { slice, offset },
                 SrcRef::Const(c) => Self::Const(c),
             }
         }
@@ -271,6 +317,7 @@ pub mod kernels {
         fn get(&self, row: usize) -> T {
             match self {
                 Self::Slice(s) => s[row],
+                Self::ShiftedSlice { slice, offset } => slice[row.saturating_sub(*offset)],
                 Self::Const(c) => *c,
             }
         }
@@ -307,6 +354,12 @@ pub mod kernels {
     {
         match (x, dx) {
             (_, ArgView::Const(dx_c)) if dx_c.is_zero() => out.fill(T::zero()),
+            (ArgView::ShiftedSlice { .. }, _) | (_, ArgView::ShiftedSlice { .. }) => {
+                for (row, outg) in out.iter_mut().enumerate() {
+                    let vals = vals1(x.get(row));
+                    *outg = partial(&vals, 0) * dx.get(row);
+                }
+            }
             (ArgView::Slice(x_s), ArgView::Slice(dx_s)) => {
                 for ((outg, &xv), &dxv) in out.iter_mut().zip_eq(x_s).zip_eq(dx_s) {
                     let vals = vals1(xv);
@@ -340,6 +393,15 @@ pub mod kernels {
         F: Fn(&[T; A], usize) -> T,
     {
         match (x, y, dx, dy) {
+            (ArgView::ShiftedSlice { .. }, _, _, _)
+            | (_, ArgView::ShiftedSlice { .. }, _, _)
+            | (_, _, ArgView::ShiftedSlice { .. }, _)
+            | (_, _, _, ArgView::ShiftedSlice { .. }) => {
+                for (row, outv) in out.iter_mut().enumerate() {
+                    let vals = vals2(x.get(row), y.get(row));
+                    *outv = partial(&vals, 0) * dx.get(row) + partial(&vals, 1) * dy.get(row);
+                }
+            }
             (ArgView::Slice(x_s), ArgView::Slice(y_s), ArgView::Slice(dx_s), ArgView::Slice(dy_s)) => {
                 let data = (x_s.iter().zip_eq(y_s)).zip_eq(dx_s.iter().zip_eq(dy_s));
                 for (outv, ((&xv, &yv), (&dxv, &dyv))) in out.iter_mut().zip_eq(data) {
@@ -414,6 +476,11 @@ pub mod kernels {
                     *outv = eval(xv);
                 }
             }
+            ArgView::ShiftedSlice { .. } => {
+                for (row, outv) in out.iter_mut().enumerate() {
+                    *outv = eval(x.get(row));
+                }
+            }
             ArgView::Const(x_c) => out.fill(eval(x_c)),
         }
     }
@@ -426,6 +493,11 @@ pub mod kernels {
         eval: impl Copy + Fn(T, T) -> T,
     ) {
         match (x, y) {
+            (ArgView::ShiftedSlice { .. }, _) | (_, ArgView::ShiftedSlice { .. }) => {
+                for (row, outv) in out.iter_mut().enumerate() {
+                    *outv = eval(x.get(row), y.get(row));
+                }
+            }
             (ArgView::Slice(x_s), ArgView::Slice(y_s)) => {
                 for (outv, (&xv, &yv)) in out.iter_mut().zip_eq(x_s.iter().zip_eq(y_s)) {
                     *outv = eval(xv, yv);

--- a/dynamic_expressions/src/evaluate_derivative.rs
+++ b/dynamic_expressions/src/evaluate_derivative.rs
@@ -102,6 +102,17 @@ fn resolve_jac_src<'a, T: Float>(
                 }
             }
         },
+        Src::Delay { feature, .. } => match target {
+            JacTarget::Variables => GradRef::Basis(feature as usize),
+            JacTarget::Constants => GradRef::Zero,
+            JacTarget::VariableDir(dir) => {
+                if feature as usize == dir {
+                    GradRef::Basis(0)
+                } else {
+                    GradRef::Zero
+                }
+            }
+        },
         Src::Const(c) => match target {
             JacTarget::Variables | JacTarget::VariableDir(_) => GradRef::Zero,
             JacTarget::Constants => GradRef::Basis(c as usize),
@@ -238,6 +249,33 @@ where
                 JacTarget::Constants => {}
                 JacTarget::VariableDir(dir) => {
                     if f as usize == dir {
+                        out_jac.fill(T::one());
+                    } else {
+                        out_jac.fill(T::zero());
+                    }
+                }
+            }
+        }
+        Src::Delay { feature, offset } => {
+            let start = feature as usize * n_rows;
+            let source = &x_data[start..start + n_rows];
+            let offset = offset as usize;
+            for (row, dst) in out_val.iter_mut().enumerate() {
+                *dst = source[row.saturating_sub(offset)];
+            }
+            match target {
+                JacTarget::Variables => {
+                    for (dir, jac_dir) in out_jac.chunks_mut(n_rows).enumerate() {
+                        if dir == feature as usize {
+                            jac_dir.fill(T::one());
+                        } else {
+                            jac_dir.fill(T::zero());
+                        }
+                    }
+                }
+                JacTarget::Constants => {}
+                JacTarget::VariableDir(dir) => {
+                    if feature as usize == dir {
                         out_jac.fill(T::one());
                     } else {
                         out_jac.fill(T::zero());

--- a/dynamic_expressions/src/lib.rs
+++ b/dynamic_expressions/src/lib.rs
@@ -21,7 +21,10 @@ pub mod utils;
 pub use {num_traits, paste};
 
 pub use crate::compile::{EvalPlan, Instr, compile_plan};
-pub use crate::evaluate::{EvalContext, EvalOptions, eval_plan_array_into, eval_tree_array, eval_tree_array_into};
+pub use crate::evaluate::{
+    EvalContext, EvalOptions, delay_validity_mask, delay_validity_mask_into, eval_plan_array_into, eval_tree_array,
+    eval_tree_array_into,
+};
 pub use crate::evaluate_derivative::{
     DiffContext, GradContext, GradMatrix, eval_diff_tree_array, eval_grad_tree_array,
 };

--- a/dynamic_expressions/src/node.rs
+++ b/dynamic_expressions/src/node.rs
@@ -1,6 +1,7 @@
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum PNode {
     Var { feature: u16 },
+    Delay { feature: u16, offset: u16 },
     Const { idx: u16 },
     Op { arity: u8, op: u16 },
 }
@@ -9,5 +10,6 @@ pub enum PNode {
 pub enum Src {
     Slot(u16),
     Var(u16),
+    Delay { feature: u16, offset: u16 },
     Const(u16),
 }

--- a/dynamic_expressions/src/node_utils.rs
+++ b/dynamic_expressions/src/node_utils.rs
@@ -39,7 +39,7 @@ fn tree_mapreduce_impl<R, B>(
 ) -> R {
     for n in nodes {
         match *n {
-            PNode::Var { .. } | PNode::Const { .. } => stack.push(f_leaf(n)),
+            PNode::Var { .. } | PNode::Delay { .. } | PNode::Const { .. } => stack.push(f_leaf(n)),
             PNode::Op { arity, .. } => {
                 let a = arity as usize;
                 let start = stack.len().checked_sub(a).expect("invalid postfix (stack underflow)");
@@ -88,15 +88,31 @@ pub fn has_operators(nodes: &[PNode]) -> bool {
 }
 
 pub fn has_variables(nodes: &[PNode]) -> bool {
-    nodes.iter().any(|n| matches!(n, PNode::Var { .. }))
+    nodes
+        .iter()
+        .any(|n| matches!(n, PNode::Var { .. } | PNode::Delay { .. }))
 }
 
 pub fn count_variable_nodes(nodes: &[PNode]) -> usize {
-    nodes.iter().filter(|n| matches!(n, PNode::Var { .. })).count()
+    nodes
+        .iter()
+        .filter(|n| matches!(n, PNode::Var { .. } | PNode::Delay { .. }))
+        .count()
 }
 
 pub fn count_operator_nodes(nodes: &[PNode]) -> usize {
     nodes.iter().filter(|n| matches!(n, PNode::Op { .. })).count()
+}
+
+pub fn max_delay(nodes: &[PNode]) -> usize {
+    nodes
+        .iter()
+        .filter_map(|n| match n {
+            PNode::Delay { offset, .. } => Some(*offset as usize),
+            _ => None,
+        })
+        .max()
+        .unwrap_or(0)
 }
 
 pub fn max_arity(nodes: &[PNode]) -> u8 {
@@ -111,14 +127,17 @@ pub fn max_arity(nodes: &[PNode]) -> u8 {
 }
 
 pub fn is_leaf(nodes: &[PNode]) -> bool {
-    matches!(nodes, [PNode::Var { .. }] | [PNode::Const { .. }])
+    matches!(
+        nodes,
+        [PNode::Var { .. }] | [PNode::Delay { .. }] | [PNode::Const { .. }]
+    )
 }
 
 pub fn is_valid_postfix(nodes: &[PNode]) -> bool {
     let mut stack: isize = 0;
     for n in nodes {
         match *n {
-            PNode::Var { .. } | PNode::Const { .. } => stack += 1,
+            PNode::Var { .. } | PNode::Delay { .. } | PNode::Const { .. } => stack += 1,
             PNode::Op { arity, .. } => {
                 let a = arity as isize;
                 if a <= 0 {
@@ -140,7 +159,7 @@ pub fn subtree_sizes(nodes: &[PNode]) -> Vec<usize> {
 
     for (i, n) in nodes.iter().enumerate() {
         match *n {
-            PNode::Var { .. } | PNode::Const { .. } => {
+            PNode::Var { .. } | PNode::Delay { .. } | PNode::Const { .. } => {
                 sizes[i] = 1;
                 stack.push(1);
             }

--- a/dynamic_expressions/src/simplify.rs
+++ b/dynamic_expressions/src/simplify.rs
@@ -21,6 +21,7 @@ struct ArenaNode<const D: usize> {
 #[derive(Clone, Copy)]
 enum ArenaNodeKind<const D: usize> {
     Var(u16),
+    Delay { feature: u16, offset: u16 },
     Const(u16),
     Op { arity: u8, op: u16, children: [usize; D] },
 }
@@ -291,6 +292,7 @@ fn combine_node<T: Float, const D: usize>(
 fn emit_postfix<const D: usize>(id: usize, arena: &[ArenaNode<D>], out: &mut Vec<PNode>) {
     match arena[id].kind {
         ArenaNodeKind::Var(f) => out.push(PNode::Var { feature: f }),
+        ArenaNodeKind::Delay { feature, offset } => out.push(PNode::Delay { feature, offset }),
         ArenaNodeKind::Const(idx) => out.push(PNode::Const { idx }),
         ArenaNodeKind::Op { arity, op, children } => {
             for &cid in children.iter().take(arity as usize) {
@@ -313,6 +315,13 @@ where
                 let id = arena.len();
                 arena.push(ArenaNode {
                     kind: ArenaNodeKind::Var(feature),
+                });
+                st.push(id);
+            }
+            PNode::Delay { feature, offset } => {
+                let id = arena.len();
+                arena.push(ArenaNode {
+                    kind: ArenaNodeKind::Delay { feature, offset },
                 });
                 st.push(id);
             }
@@ -401,7 +410,7 @@ where
 
     for node in expr.nodes.iter().copied() {
         match node {
-            PNode::Var { .. } => {
+            PNode::Var { .. } | PNode::Delay { .. } => {
                 out_nodes.push(node);
                 push_nonconst_frame(&mut stack, out_nodes.len() - 1);
             }

--- a/dynamic_expressions/src/strings.rs
+++ b/dynamic_expressions/src/strings.rs
@@ -150,6 +150,9 @@ where
         &expr.nodes,
         |n| match *n {
             PNode::Var { feature } => default_string_variable(feature, names),
+            PNode::Delay { feature, offset } => {
+                format!("delay({}, {})", default_string_variable(feature, names), offset)
+            }
             PNode::Const { idx } => format_constant(&expr.consts[usize::from(idx)], opts.print_precision),
             _ => unreachable!("branch node in leaf mapper"),
         },

--- a/symbolic_regression/examples/delay_benchmark.rs
+++ b/symbolic_regression/examples/delay_benchmark.rs
@@ -1,0 +1,243 @@
+use std::collections::HashMap;
+use std::fs;
+use std::time::Instant;
+
+use dynamic_expressions::{StringTreeOptions, node_utils};
+use ndarray::{Array1, Array2};
+use symbolic_regression::prelude::*;
+
+const D: usize = 3;
+const EXCLUDED: [&str; 4] = ["target", "target_low", "target_high", "weight"];
+
+struct Frame {
+    headers: Vec<String>,
+    rows: Vec<Vec<f32>>,
+}
+
+fn read_csv(path: &str) -> Frame {
+    let text = fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"));
+    let mut lines = text.lines();
+    let headers: Vec<String> = lines
+        .next()
+        .unwrap_or_else(|| panic!("empty csv: {path}"))
+        .split(',')
+        .map(str::to_string)
+        .collect();
+    let rows = lines
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            line.split(',')
+                .map(|v| v.parse::<f32>().unwrap_or_else(|err| panic!("bad float {v}: {err}")))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    Frame { headers, rows }
+}
+
+fn column_map(headers: &[String]) -> HashMap<&str, usize> {
+    headers
+        .iter()
+        .enumerate()
+        .map(|(idx, name)| (name.as_str(), idx))
+        .collect()
+}
+
+fn feature_names(headers: &[String]) -> Vec<String> {
+    headers
+        .iter()
+        .filter(|name| !EXCLUDED.contains(&name.as_str()))
+        .cloned()
+        .collect()
+}
+
+fn arrays(frame: &Frame, features: &[String]) -> (Array2<f32>, Array1<f32>, Array1<f32>) {
+    let columns = column_map(&frame.headers);
+    let n_rows = frame.rows.len();
+    let mut x = Array2::<f32>::zeros((features.len(), n_rows));
+    let mut y = Array1::<f32>::zeros(n_rows);
+    let mut w = Array1::<f32>::zeros(n_rows);
+    for (row_idx, row) in frame.rows.iter().enumerate() {
+        for (feature_idx, feature) in features.iter().enumerate() {
+            x[(feature_idx, row_idx)] = row[columns[feature.as_str()]];
+        }
+        y[row_idx] = row[columns["target"]];
+        w[row_idx] = row[columns["weight"]];
+    }
+    (x, y, w)
+}
+
+fn mse(pred: &[f32], y: &Array1<f32>, valid_start: usize) -> f64 {
+    let pred = &pred[valid_start..];
+    let y = &y.as_slice().unwrap()[valid_start..];
+    pred.iter()
+        .zip(y.iter())
+        .map(|(&p, &t)| {
+            let err = (p - t) as f64;
+            err * err
+        })
+        .sum::<f64>()
+        / pred.len() as f64
+}
+
+fn r2(pred: &[f32], y: &Array1<f32>, valid_start: usize) -> f64 {
+    let pred = &pred[valid_start..];
+    let y = &y.as_slice().unwrap()[valid_start..];
+    let mean = y.iter().map(|&v| v as f64).sum::<f64>() / y.len() as f64;
+    let ss_res = pred
+        .iter()
+        .zip(y.iter())
+        .map(|(&p, &t)| {
+            let err = (p - t) as f64;
+            err * err
+        })
+        .sum::<f64>();
+    let ss_tot = y
+        .iter()
+        .map(|&t| {
+            let err = t as f64 - mean;
+            err * err
+        })
+        .sum::<f64>();
+    1.0 - ss_res / ss_tot
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut train_path = String::new();
+    let mut test_path = String::new();
+    let mut niterations = 8usize;
+    let mut populations = 4usize;
+    let mut population_size = 30usize;
+    let mut ncycles_per_iteration = 380usize;
+    let mut optimizer_iterations = 8usize;
+    let mut maxsize = 18usize;
+    let mut max_delay = 0usize;
+    let mut delay_probability = 0.0f64;
+    let mut parsimony = 0.0f64;
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--train" => train_path = args.next().expect("--train requires a path"),
+            "--test" => test_path = args.next().expect("--test requires a path"),
+            "--niterations" => {
+                niterations = args
+                    .next()
+                    .expect("--niterations requires a value")
+                    .parse()
+                    .expect("bad --niterations")
+            }
+            "--populations" => {
+                populations = args
+                    .next()
+                    .expect("--populations requires a value")
+                    .parse()
+                    .expect("bad --populations")
+            }
+            "--population-size" => {
+                population_size = args
+                    .next()
+                    .expect("--population-size requires a value")
+                    .parse()
+                    .expect("bad --population-size")
+            }
+            "--cycles" => {
+                ncycles_per_iteration = args
+                    .next()
+                    .expect("--cycles requires a value")
+                    .parse()
+                    .expect("bad --cycles")
+            }
+            "--optimizer-iterations" => {
+                optimizer_iterations = args
+                    .next()
+                    .expect("--optimizer-iterations requires a value")
+                    .parse()
+                    .expect("bad --optimizer-iterations")
+            }
+            "--maxsize" => {
+                maxsize = args
+                    .next()
+                    .expect("--maxsize requires a value")
+                    .parse()
+                    .expect("bad --maxsize")
+            }
+            "--max-delay" => {
+                max_delay = args
+                    .next()
+                    .expect("--max-delay requires a value")
+                    .parse()
+                    .expect("bad --max-delay")
+            }
+            "--delay-probability" => {
+                delay_probability = args
+                    .next()
+                    .expect("--delay-probability requires a value")
+                    .parse()
+                    .expect("bad --delay-probability")
+            }
+            "--parsimony" => {
+                parsimony = args
+                    .next()
+                    .expect("--parsimony requires a value")
+                    .parse()
+                    .expect("bad --parsimony")
+            }
+            other => panic!("unknown argument: {other}"),
+        }
+    }
+    assert!(!train_path.is_empty(), "--train is required");
+    assert!(!test_path.is_empty(), "--test is required");
+
+    let train = read_csv(&train_path);
+    let test = read_csv(&test_path);
+    let features = feature_names(&train.headers);
+    let (x_train, y_train, weights) = arrays(&train, &features);
+    let (x_test, y_test, _) = arrays(&test, &features);
+
+    let dataset = Dataset::with_weights_and_names(x_train, y_train, Some(weights), features.clone());
+    let operators = BuiltinOpsF32::from_names(["cos", "sin", "+", "sub", "*", "/"]).unwrap();
+    let options = Options::<f32, D> {
+        seed: 1009,
+        niterations,
+        populations,
+        population_size,
+        ncycles_per_iteration,
+        optimizer_iterations,
+        maxsize,
+        max_delay,
+        delay_probability,
+        parsimony,
+        maxdepth: 8,
+        progress: false,
+        deterministic: true,
+        operators,
+        ..Default::default()
+    };
+
+    let start = Instant::now();
+    let result = equation_search::<f32, BuiltinOpsF32, D>(&dataset, &options);
+    let elapsed = start.elapsed().as_secs_f64();
+
+    let (pred, complete) =
+        eval_tree_array::<f32, BuiltinOpsF32, D>(&result.best.expr, x_test.view(), &EvalOptions::default());
+    let expression = string_tree(
+        &result.best.expr,
+        StringTreeOptions {
+            variable_names: Some(&features),
+            ..Default::default()
+        },
+    );
+    let valid_start = node_utils::max_delay(&result.best.expr.nodes).min(y_test.len().saturating_sub(1));
+
+    println!("{{");
+    println!("  \"engine\": \"symbolic_regression_rs\",");
+    println!("  \"status\": \"ok\",");
+    println!("  \"wall_seconds\": {elapsed},");
+    println!("  \"feature_count\": {},", features.len());
+    println!("  \"expression\": {:?},", expression);
+    println!("  \"train_loss\": {},", result.best.loss);
+    println!("  \"valid_start\": {},", valid_start);
+    println!("  \"test_mse\": {},", mse(&pred, &y_test, valid_start));
+    println!("  \"test_r2\": {},", r2(&pred, &y_test, valid_start));
+    println!("  \"prediction_complete\": {}", complete);
+    println!("}}");
+}

--- a/symbolic_regression/src/check_constraints.rs
+++ b/symbolic_regression/src/check_constraints.rs
@@ -111,7 +111,7 @@ fn check_nested_constraints<const D: usize>(nodes: &[PNode], nested: &NestedCons
         let mut out: Vec<u16> = Vec::with_capacity(nodes.len());
         for n in nodes {
             match *n {
-                PNode::Var { .. } | PNode::Const { .. } => {
+                PNode::Var { .. } | PNode::Delay { .. } | PNode::Const { .. } => {
                     st.push(0);
                     out.push(0);
                 }

--- a/symbolic_regression/src/complexity.rs
+++ b/symbolic_regression/src/complexity.rs
@@ -25,6 +25,18 @@ pub(crate) fn compute_custom_complexity_checked<T: Float, const D: usize>(
                     .unwrap_or(options.complexity_of_variables);
                 st.push(c as usize);
             }
+            PNode::Delay { feature, .. } => {
+                let idx = feature as usize;
+                let c = options
+                    .variable_complexities
+                    .as_ref()
+                    .and_then(|v| v.get(idx))
+                    .copied()
+                    .unwrap_or(options.complexity_of_variables);
+                st.push(
+                    c as usize + options.complexity_of_delay as usize + options.complexity_of_delay_offset as usize,
+                );
+            }
             PNode::Const { .. } => st.push(options.complexity_of_constants as usize),
             PNode::Op { arity, op } => {
                 let a = arity as usize;

--- a/symbolic_regression/src/constant_optimization.rs
+++ b/symbolic_regression/src/constant_optimization.rs
@@ -1,7 +1,7 @@
 use std::ops::AddAssign;
 
 use dynamic_expressions::utils::ZipEq;
-use dynamic_expressions::{EvalOptions, GradContext, OperatorSet};
+use dynamic_expressions::{EvalOptions, GradContext, OperatorSet, node_utils};
 use fastrand::Rng;
 use num_traits::{Float, FromPrimitive, ToPrimitive};
 
@@ -18,6 +18,7 @@ struct EvalWorkspace<'a, T: Float + AddAssign, const D: usize> {
     grad_ctx: &'a mut GradContext<T, D>,
     eval_opts: EvalOptions,
     dloss_dyhat: Vec<T>,
+    loss_weights: Vec<T>,
 }
 
 impl<'a, T: Float + AddAssign, const D: usize> EvalWorkspace<'a, T, D> {
@@ -39,7 +40,23 @@ impl<'a, T: Float + AddAssign, const D: usize> EvalWorkspace<'a, T, D> {
             grad_ctx,
             eval_opts,
             dloss_dyhat: vec![T::zero(); dataset.n_rows],
+            loss_weights: vec![T::zero(); dataset.n_rows],
         }
+    }
+
+    fn fill_delay_weights(&mut self, max_delay: usize) -> bool {
+        if !self.dataset.has_valid_delay_rows(max_delay) {
+            return false;
+        }
+        let base_weights = self.dataset.weights_slice();
+        for row in 0..self.dataset.n_rows {
+            self.loss_weights[row] = if self.dataset.delay_valid_at(row, max_delay) {
+                base_weights.map_or_else(T::one, |w| w[row])
+            } else {
+                T::zero()
+            };
+        }
+        true
     }
 
     fn loss_only<Ops>(
@@ -62,11 +79,39 @@ impl<'a, T: Float + AddAssign, const D: usize> EvalWorkspace<'a, T, D> {
             return None;
         }
 
-        let loss = self.options.loss.loss(
-            &self.evaluator.yhat,
-            self.dataset.y.as_slice().unwrap(),
-            self.dataset.weights.as_ref().and_then(|w| w.as_slice()),
-        );
+        let max_delay = node_utils::max_delay(&expr.nodes);
+        let loss = if max_delay == 0 {
+            self.options.loss.loss(
+                &self.evaluator.yhat,
+                self.dataset.y.as_slice().unwrap(),
+                self.dataset.weights_slice(),
+            )
+        } else if self.dataset.sequence_ids.is_none() {
+            let valid_start = max_delay.min(self.dataset.n_rows);
+            if valid_start >= self.dataset.n_rows {
+                return None;
+            }
+            let weights = self
+                .dataset
+                .weights
+                .as_ref()
+                .and_then(|w| w.as_slice())
+                .map(|w| &w[valid_start..]);
+            self.options.loss.loss(
+                &self.evaluator.yhat[valid_start..],
+                &self.dataset.y.as_slice().unwrap()[valid_start..],
+                weights,
+            )
+        } else {
+            if !self.fill_delay_weights(max_delay) {
+                return None;
+            }
+            self.options.loss.loss(
+                &self.evaluator.yhat,
+                self.dataset.y.as_slice().unwrap(),
+                Some(&self.loss_weights),
+            )
+        };
         if !loss.is_finite() {
             return None;
         }
@@ -98,21 +143,69 @@ impl<'a, T: Float + AddAssign, const D: usize> EvalWorkspace<'a, T, D> {
             return None;
         }
 
-        let loss = self.options.loss.loss(
-            &yhat,
-            self.dataset.y.as_slice().unwrap(),
-            self.dataset.weights.as_ref().and_then(|w| w.as_slice()),
-        );
+        let max_delay = node_utils::max_delay(&expr.nodes);
+        let loss = if max_delay == 0 {
+            self.options
+                .loss
+                .loss(&yhat, self.dataset.y.as_slice().unwrap(), self.dataset.weights_slice())
+        } else if self.dataset.sequence_ids.is_none() {
+            let valid_start = max_delay.min(self.dataset.n_rows);
+            if valid_start >= self.dataset.n_rows {
+                return None;
+            }
+            let weights = self
+                .dataset
+                .weights
+                .as_ref()
+                .and_then(|w| w.as_slice())
+                .map(|w| &w[valid_start..]);
+            self.options.loss.loss(
+                &yhat[valid_start..],
+                &self.dataset.y.as_slice().unwrap()[valid_start..],
+                weights,
+            )
+        } else {
+            if !self.fill_delay_weights(max_delay) {
+                return None;
+            }
+            self.options
+                .loss
+                .loss(&yhat, self.dataset.y.as_slice().unwrap(), Some(&self.loss_weights))
+        };
         if !loss.is_finite() {
             return None;
         }
 
-        self.options.loss.dloss_dyhat(
-            &yhat,
-            self.dataset.y.as_slice().unwrap(),
-            self.dataset.weights.as_ref().and_then(|w| w.as_slice()),
-            &mut self.dloss_dyhat,
-        );
+        if max_delay == 0 {
+            self.options.loss.dloss_dyhat(
+                &yhat,
+                self.dataset.y.as_slice().unwrap(),
+                self.dataset.weights_slice(),
+                &mut self.dloss_dyhat,
+            );
+        } else if self.dataset.sequence_ids.is_none() {
+            let valid_start = max_delay.min(self.dataset.n_rows);
+            let weights = self
+                .dataset
+                .weights
+                .as_ref()
+                .and_then(|w| w.as_slice())
+                .map(|w| &w[valid_start..]);
+            self.options.loss.dloss_dyhat(
+                &yhat[valid_start..],
+                &self.dataset.y.as_slice().unwrap()[valid_start..],
+                weights,
+                &mut self.dloss_dyhat[valid_start..],
+            );
+            self.dloss_dyhat[..valid_start].fill(T::zero());
+        } else {
+            self.options.loss.dloss_dyhat(
+                &yhat,
+                self.dataset.y.as_slice().unwrap(),
+                Some(&self.loss_weights),
+                &mut self.dloss_dyhat,
+            );
+        }
 
         for (ci, gout) in grad_out.iter_mut().enumerate() {
             if ci >= n_params {

--- a/symbolic_regression/src/dataset.rs
+++ b/symbolic_regression/src/dataset.rs
@@ -57,6 +57,8 @@ pub struct Dataset<T: Float> {
     pub n_rows: usize,
     pub weights: Option<Array1<T>>,
     pub variable_names: Vec<String>,
+    /// Optional sequence/group id per row. Delays are valid only within a sequence.
+    pub sequence_ids: Option<Vec<usize>>,
     /// Weighted mean of `y` (or unweighted mean when no weights).
     pub avg_y: T,
 }
@@ -67,6 +69,7 @@ impl<T: Float> Dataset<T> {
         y: Array1<T>,
         weights: Option<Array1<T>>,
         variable_names: Vec<String>,
+        sequence_ids: Option<Vec<usize>>,
         avg_y: Option<T>,
     ) -> Self {
         let x = x.as_standard_layout().to_owned();
@@ -74,6 +77,13 @@ impl<T: Float> Dataset<T> {
         assert_eq!(y.len(), n_rows);
         if let Some(ref w) = weights {
             assert_eq!(w.len(), n_rows);
+        }
+        if let Some(ref ids) = sequence_ids {
+            assert_eq!(ids.len(), n_rows);
+            assert!(
+                ids.windows(2).all(|w| w[0] <= w[1]),
+                "sequence_ids must be nondecreasing so each sequence is contiguous"
+            );
         }
 
         let avg_y = avg_y
@@ -86,12 +96,13 @@ impl<T: Float> Dataset<T> {
             n_rows,
             weights,
             variable_names,
+            sequence_ids,
             avg_y,
         }
     }
 
     pub fn new(x: Array2<T>, y: Array1<T>) -> Self {
-        Self::build_dataset(x, y, None, Vec::new(), None)
+        Self::build_dataset(x, y, None, Vec::new(), None, None)
     }
 
     pub fn with_weights_and_names(
@@ -100,7 +111,17 @@ impl<T: Float> Dataset<T> {
         weights: Option<Array1<T>>,
         variable_names: Vec<String>,
     ) -> Self {
-        Self::build_dataset(x, y, weights, variable_names, None)
+        Self::build_dataset(x, y, weights, variable_names, None, None)
+    }
+
+    pub fn with_weights_names_and_sequence_ids(
+        x: Array2<T>,
+        y: Array1<T>,
+        weights: Option<Array1<T>>,
+        variable_names: Vec<String>,
+        sequence_ids: Vec<usize>,
+    ) -> Self {
+        Self::build_dataset(x, y, weights, variable_names, Some(sequence_ids), None)
     }
 
     pub fn y_slice(&self) -> &[T] {
@@ -109,6 +130,24 @@ impl<T: Float> Dataset<T> {
 
     pub fn weights_slice(&self) -> Option<&[T]> {
         self.weights.as_ref().and_then(|w| w.as_slice())
+    }
+
+    pub fn sequence_ids_slice(&self) -> Option<&[usize]> {
+        self.sequence_ids.as_deref()
+    }
+
+    pub fn delay_valid_at(&self, row: usize, offset: usize) -> bool {
+        if row < offset {
+            return false;
+        }
+        match self.sequence_ids.as_deref() {
+            None => true,
+            Some(ids) => ids[row] == ids[row - offset],
+        }
+    }
+
+    pub fn has_valid_delay_rows(&self, offset: usize) -> bool {
+        (0..self.n_rows).any(|row| self.delay_valid_at(row, offset))
     }
 
     pub fn compute_avg_y(y: &[T], weights: Option<&[T]>) -> T {
@@ -140,7 +179,7 @@ impl<T: Float> Dataset<T> {
         let x = Array2::<T>::zeros((full.n_features, batch_size));
         let y = Array1::<T>::zeros(batch_size);
         let weights = full.weights.as_ref().map(|_| Array1::<T>::zeros(batch_size));
-        Self::build_dataset(x, y, weights, full.variable_names.clone(), Some(full.avg_y))
+        Self::build_dataset(x, y, weights, full.variable_names.clone(), None, Some(full.avg_y))
     }
 
     pub fn resample_from(&mut self, full: &Dataset<T>, rng: &mut Rng) {

--- a/symbolic_regression/src/mutate.rs
+++ b/symbolic_regression/src/mutate.rs
@@ -22,6 +22,7 @@ pub enum MutationChoice {
     MutateConstant,
     MutateOperator,
     MutateFeature,
+    MutateDelayOffset,
     SwapOperands,
     RotateTree,
     AddNode,
@@ -68,7 +69,7 @@ pub fn condition_mutation_weights<T: Float + AddAssign, Ops, const D: usize>(
         .expr
         .nodes
         .iter()
-        .all(|n| matches!(n, PNode::Var { .. } | PNode::Const { .. }));
+        .all(|n| matches!(n, PNode::Var { .. } | PNode::Delay { .. } | PNode::Const { .. }));
     if tree_is_leaf {
         weights.mutate_operator = 0.0;
         weights.swap_operands = 0.0;
@@ -79,6 +80,9 @@ pub fn condition_mutation_weights<T: Float + AddAssign, Ops, const D: usize>(
             weights.mutate_constant = 0.0;
         } else {
             weights.mutate_feature = 0.0;
+        }
+        if options.max_delay <= 1 || !member.expr.nodes.iter().any(|n| matches!(n, PNode::Delay { .. })) {
+            weights.mutate_delay_offset = 0.0;
         }
         return;
     }
@@ -92,6 +96,10 @@ pub fn condition_mutation_weights<T: Float + AddAssign, Ops, const D: usize>(
 
     if nfeatures <= 1 {
         weights.mutate_feature = 0.0;
+    }
+
+    if options.max_delay <= 1 || !member.expr.nodes.iter().any(|n| matches!(n, PNode::Delay { .. })) {
+        weights.mutate_delay_offset = 0.0;
     }
 
     let complexity = member.complexity;
@@ -110,6 +118,7 @@ pub fn sample_mutation(rng: &mut Rng, weights: &MutationWeights) -> MutationChoi
         (MutationChoice::MutateConstant, weights.mutate_constant),
         (MutationChoice::MutateOperator, weights.mutate_operator),
         (MutationChoice::MutateFeature, weights.mutate_feature),
+        (MutationChoice::MutateDelayOffset, weights.mutate_delay_offset),
         (MutationChoice::SwapOperands, weights.swap_operands),
         (MutationChoice::RotateTree, weights.rotate_tree),
         (MutationChoice::AddNode, weights.add_node),
@@ -175,6 +184,10 @@ impl MutationChoice {
                 mutation_functions::mutate_feature_in_place(rng, &mut expr, n_features);
                 MutationResult::ProposedExpr { expr, evals: 0.0 }
             }
+            MutationChoice::MutateDelayOffset => {
+                mutation_functions::mutate_delay_offset_in_place(rng, &mut expr, options.max_delay);
+                MutationResult::ProposedExpr { expr, evals: 0.0 }
+            }
             MutationChoice::SwapOperands => {
                 let _ = mutation_functions::swap_operands_in_place(rng, &mut expr);
                 MutationResult::ProposedExpr { expr, evals: 0.0 }
@@ -184,11 +197,17 @@ impl MutationChoice {
                 MutationResult::ProposedExpr { expr, evals: 0.0 }
             }
             MutationChoice::AddNode => {
-                let _ = mutation_functions::add_node_in_place(rng, &mut expr, &options.operators, n_features);
+                let _ = mutation_functions::add_node_in_place(rng, &mut expr, &options.operators, n_features, options);
                 MutationResult::ProposedExpr { expr, evals: 0.0 }
             }
             MutationChoice::InsertNode => {
-                let _ = mutation_functions::insert_random_op_in_place(rng, &mut expr, &options.operators, n_features);
+                let _ = mutation_functions::insert_random_op_in_place(
+                    rng,
+                    &mut expr,
+                    &options.operators,
+                    n_features,
+                    options,
+                );
                 MutationResult::ProposedExpr { expr, evals: 0.0 }
             }
             MutationChoice::DeleteNode => {
@@ -220,7 +239,7 @@ impl MutationChoice {
                 // Match SymbolicRegression.jl: sample a *uniform* random size in 1:curmaxsize.
                 let max_size = curmaxsize.max(1).min(options.maxsize.max(1));
                 let target_size = usize_range_inclusive(rng, 1..=max_size);
-                let expr = mutation_functions::random_expr(rng, &options.operators, n_features, target_size);
+                let expr = mutation_functions::random_expr(rng, &options.operators, n_features, target_size, options);
                 MutationResult::ProposedExpr { expr, evals: 0.0 }
             }
             MutationChoice::DoNothing => {

--- a/symbolic_regression/src/mutation_functions.rs
+++ b/symbolic_regression/src/mutation_functions.rs
@@ -10,7 +10,21 @@ use crate::operator_selection::OperatorsSampling;
 use crate::options::Options;
 use crate::random::{standard_normal, usize_range, usize_range_excl};
 
-fn random_leaf<T: Float>(rng: &mut Rng, n_features: usize, consts: &mut Vec<T>) -> PNode {
+fn random_leaf<T: Float, const D: usize>(
+    rng: &mut Rng,
+    n_features: usize,
+    consts: &mut Vec<T>,
+    options: &Options<T, D>,
+) -> PNode {
+    if n_features > 0 && options.max_delay > 0 && rng.f64() < options.delay_probability {
+        let feature: u16 = usize_range(rng, 0..n_features)
+            .try_into()
+            .unwrap_or_else(|_| panic!("too many features to index in u16"));
+        let offset: u16 = usize_range(rng, 1..options.max_delay + 1)
+            .try_into()
+            .unwrap_or_else(|_| panic!("max_delay too large to index in u16"));
+        return PNode::Delay { feature, offset };
+    }
     if rng.bool() {
         let val_f64: f64 = standard_normal(rng);
         let val = T::from(val_f64).unwrap();
@@ -33,11 +47,12 @@ pub fn random_expr<T: Float, Ops, const D: usize>(
     operators: &Operators<D>,
     n_features: usize,
     target_size: usize,
+    options: &Options<T, D>,
 ) -> PostfixExpr<T, Ops, D> {
     assert!(target_size >= 1);
     let mut nodes: Vec<PNode> = Vec::with_capacity(target_size);
     let mut consts: Vec<T> = Vec::new();
-    nodes.push(random_leaf(rng, n_features, &mut consts));
+    nodes.push(random_leaf(rng, n_features, &mut consts, options));
 
     while nodes.len() < target_size && operators.total_ops_up_to(D.min(target_size - nodes.len())) > 0 {
         let rem = target_size - nodes.len();
@@ -48,13 +63,15 @@ pub fn random_expr<T: Float, Ops, const D: usize>(
         let leaf_positions: Vec<usize> = nodes
             .iter()
             .enumerate()
-            .filter_map(|(i, n)| matches!(n, PNode::Var { .. } | PNode::Const { .. }).then_some(i))
+            .filter_map(|(i, n)| {
+                matches!(n, PNode::Var { .. } | PNode::Delay { .. } | PNode::Const { .. }).then_some(i)
+            })
             .collect();
         let leaf_idx = leaf_positions[usize_range(rng, 0..leaf_positions.len())];
 
         let mut repl: Vec<PNode> = Vec::with_capacity(arity + 1);
         for _ in 0..arity {
-            repl.push(random_leaf(rng, n_features, &mut consts));
+            repl.push(random_leaf(rng, n_features, &mut consts, options));
         }
         repl.push(PNode::Op {
             arity: arity as u8,
@@ -78,6 +95,7 @@ pub fn random_expr_append_ops<T: Float, Ops, const D: usize>(
     n_features: usize,
     n_append_ops: usize,
     max_size: usize,
+    options: &Options<T, D>,
 ) -> PostfixExpr<T, Ops, D> {
     let max_size = max_size.max(1);
     let mut expr = PostfixExpr::<T, Ops, D>::zero();
@@ -98,7 +116,9 @@ pub fn random_expr_append_ops<T: Float, Ops, const D: usize>(
             .nodes
             .iter()
             .enumerate()
-            .filter_map(|(i, n)| matches!(n, PNode::Var { .. } | PNode::Const { .. }).then_some(i))
+            .filter_map(|(i, n)| {
+                matches!(n, PNode::Var { .. } | PNode::Delay { .. } | PNode::Const { .. }).then_some(i)
+            })
             .collect();
         if leaf_positions.is_empty() {
             break;
@@ -107,7 +127,7 @@ pub fn random_expr_append_ops<T: Float, Ops, const D: usize>(
 
         let mut repl: Vec<PNode> = Vec::with_capacity(arity + 1);
         for _ in 0..arity {
-            repl.push(random_leaf(rng, n_features, &mut expr.consts));
+            repl.push(random_leaf(rng, n_features, &mut expr.consts, options));
         }
         repl.push(PNode::Op {
             arity: arity as u8,
@@ -140,7 +160,7 @@ fn var_node_indices(nodes: &[PNode]) -> Vec<usize> {
     nodes
         .iter()
         .enumerate()
-        .filter_map(|(i, n)| matches!(n, PNode::Var { .. }).then_some(i))
+        .filter_map(|(i, n)| matches!(n, PNode::Var { .. } | PNode::Delay { .. }).then_some(i))
         .collect()
 }
 
@@ -225,13 +245,44 @@ pub(crate) fn mutate_feature_in_place<T, Ops, const D: usize>(
         return;
     }
     let node_i = rng.choice(idxs).unwrap();
-    let PNode::Var { ref mut feature } = &mut expr.nodes[node_i] else {
-        unreachable!("expected var node");
+    let feature = match &mut expr.nodes[node_i] {
+        PNode::Var { feature } | PNode::Delay { feature, .. } => feature,
+        _ => unreachable!("expected variable-like node"),
     };
     let old = usize::from(*feature);
     assert!(old < n_features, "feature index out of bounds");
     let new_feature = usize_range_excl(rng, 0..n_features, old);
     *feature = new_feature as u16;
+}
+
+pub(crate) fn mutate_delay_offset_in_place<T, Ops, const D: usize>(
+    rng: &mut Rng,
+    expr: &mut PostfixExpr<T, Ops, D>,
+    max_delay: usize,
+) {
+    if max_delay <= 1 {
+        return;
+    }
+    let idxs: Vec<usize> = expr
+        .nodes
+        .iter()
+        .enumerate()
+        .filter_map(|(i, n)| matches!(n, PNode::Delay { .. }).then_some(i))
+        .collect();
+    if idxs.is_empty() {
+        return;
+    }
+    let node_i = rng.choice(idxs).unwrap();
+    let PNode::Delay { offset, .. } = &mut expr.nodes[node_i] else {
+        unreachable!("expected delay node");
+    };
+    let old = usize::from(*offset);
+    let new_offset = if old <= max_delay {
+        usize_range_excl(rng, 1..max_delay + 1, old)
+    } else {
+        usize_range(rng, 1..max_delay + 1)
+    };
+    *offset = new_offset as u16;
 }
 
 pub(crate) fn is_swappable_op(node: &PNode) -> bool {
@@ -301,7 +352,7 @@ fn subtree_sizes_into(nodes: &[PNode], sizes: &mut Vec<usize>, stack: &mut Vec<u
 
     for (i, n) in nodes.iter().enumerate() {
         match *n {
-            PNode::Var { .. } | PNode::Const { .. } => {
+            PNode::Var { .. } | PNode::Delay { .. } | PNode::Const { .. } => {
                 sizes[i] = 1;
                 stack.push(1);
             }
@@ -499,6 +550,7 @@ pub fn insert_random_op_in_place<T: Float, Ops, const D: usize>(
     expr: &mut PostfixExpr<T, Ops, D>,
     operators: &Operators<D>,
     n_features: usize,
+    options: &Options<T, D>,
 ) -> bool {
     if expr.nodes.is_empty() {
         return false;
@@ -520,7 +572,7 @@ pub fn insert_random_op_in_place<T: Float, Ops, const D: usize>(
         if j == carry_pos {
             new_sub.extend_from_slice(&old_sub);
         } else {
-            new_sub.push(random_leaf(rng, n_features, &mut expr.consts));
+            new_sub.push(random_leaf(rng, n_features, &mut expr.consts, options));
         }
     }
     new_sub.push(PNode::Op {
@@ -537,6 +589,7 @@ pub(crate) fn prepend_random_op_in_place<T: Float, Ops, const D: usize>(
     expr: &mut PostfixExpr<T, Ops, D>,
     operators: &Operators<D>,
     n_features: usize,
+    options: &Options<T, D>,
 ) -> bool {
     if expr.nodes.is_empty() {
         return false;
@@ -554,7 +607,7 @@ pub(crate) fn prepend_random_op_in_place<T: Float, Ops, const D: usize>(
         if j == carry_pos {
             new_nodes.extend_from_slice(&old);
         } else {
-            new_nodes.push(random_leaf(rng, n_features, &mut expr.consts));
+            new_nodes.push(random_leaf(rng, n_features, &mut expr.consts, options));
         }
     }
     new_nodes.push(PNode::Op {
@@ -571,6 +624,7 @@ pub(crate) fn append_random_op_in_place<T: Float, Ops, const D: usize>(
     expr: &mut PostfixExpr<T, Ops, D>,
     operators: &Operators<D>,
     n_features: usize,
+    options: &Options<T, D>,
 ) -> bool {
     if expr.nodes.is_empty() {
         return false;
@@ -583,7 +637,7 @@ pub(crate) fn append_random_op_in_place<T: Float, Ops, const D: usize>(
         .nodes
         .iter()
         .enumerate()
-        .filter_map(|(i, n)| matches!(n, PNode::Var { .. } | PNode::Const { .. }).then_some(i))
+        .filter_map(|(i, n)| matches!(n, PNode::Var { .. } | PNode::Delay { .. } | PNode::Const { .. }).then_some(i))
         .collect();
     if leaf_positions.is_empty() {
         return false;
@@ -595,7 +649,7 @@ pub(crate) fn append_random_op_in_place<T: Float, Ops, const D: usize>(
 
     let mut replace_with: Vec<PNode> = Vec::with_capacity(arity + 1);
     for _ in 0..arity {
-        replace_with.push(random_leaf(rng, n_features, &mut expr.consts));
+        replace_with.push(random_leaf(rng, n_features, &mut expr.consts, options));
     }
     replace_with.push(PNode::Op {
         arity: arity as u8,
@@ -612,11 +666,12 @@ pub(crate) fn add_node_in_place<T: Float, Ops, const D: usize>(
     expr: &mut PostfixExpr<T, Ops, D>,
     operators: &Operators<D>,
     n_features: usize,
+    options: &Options<T, D>,
 ) -> bool {
     if rng.bool() {
-        append_random_op_in_place(rng, expr, operators, n_features)
+        append_random_op_in_place(rng, expr, operators, n_features, options)
     } else {
-        prepend_random_op_in_place(rng, expr, operators, n_features)
+        prepend_random_op_in_place(rng, expr, operators, n_features, options)
     }
 }
 
@@ -680,6 +735,7 @@ pub(crate) fn crossover_trees<T: Clone, Ops, const D: usize>(
                     out.push(PNode::Const { idx: new_idx });
                 }
                 PNode::Var { feature } => out.push(PNode::Var { feature }),
+                PNode::Delay { feature, offset } => out.push(PNode::Delay { feature, offset }),
                 PNode::Op { arity, op } => out.push(PNode::Op { arity, op }),
             }
         }

--- a/symbolic_regression/src/options.rs
+++ b/symbolic_regression/src/options.rs
@@ -30,6 +30,8 @@ macro_rules! sr_mutation_weights_spec {
                 (f64, 0.293, "mw-mutate-operator"),
             mutate_feature:
                 (f64, 0.1, "mw-mutate-feature"),
+            mutate_delay_offset:
+                (f64, 0.1, "mw-mutate-delay-offset"),
             swap_operands:
                 (f64, 0.198, "mw-swap-operands"),
             rotate_tree:
@@ -77,12 +79,20 @@ macro_rules! sr_options_spec {
                     (u16, 1, "complexity-of-constants"),
                 complexity_of_variables:
                     (u16, 1, "complexity-of-variables"),
+                complexity_of_delay:
+                    (u16, 1, "complexity-of-delay"),
+                complexity_of_delay_offset:
+                    (u16, 1, "complexity-of-delay-offset"),
                 maxsize:
                     (usize, 30, "maxsize"),
                 maxdepth:
                     (usize, 30, "maxdepth"),
+                max_delay:
+                    (usize, 0, "max-delay"),
                 warmup_maxsize_by:
                     (f32, 0.0, "warmup-maxsize-by"),
+                delay_probability:
+                    (f64, 0.0, "delay-probability"),
                 parsimony:
                     (f64, 0.0, "parsimony"),
                 adaptive_parsimony_scaling:

--- a/symbolic_regression/src/pop_member.rs
+++ b/symbolic_regression/src/pop_member.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use dynamic_expressions::expression::PostfixExpr;
-use dynamic_expressions::{EvalOptions, EvalPlan};
+use dynamic_expressions::{EvalOptions, EvalPlan, node_utils};
 use num_traits::Float;
 #[cfg(target_arch = "wasm32")]
 use web_time::{SystemTime, UNIX_EPOCH};
@@ -68,6 +68,7 @@ impl<T: Float, Ops, const D: usize> Clone for PopMember<T, Ops, D> {
 pub struct Evaluator<T: Float, const D: usize> {
     pub eval_opts: EvalOptions,
     pub yhat: Vec<T>,
+    pub loss_weights: Vec<T>,
     pub scratch: ndarray::Array2<T>,
 }
 
@@ -79,6 +80,7 @@ impl<T: Float, const D: usize> Evaluator<T, D> {
                 early_exit: true,
             },
             yhat: vec![T::zero(); n_rows],
+            loss_weights: vec![T::zero(); n_rows],
             scratch: ndarray::Array2::zeros((0, 0)),
         }
     }
@@ -86,6 +88,9 @@ impl<T: Float, const D: usize> Evaluator<T, D> {
     pub fn ensure_n_rows(&mut self, n_rows: usize) {
         if self.yhat.len() != n_rows {
             self.yhat.resize(n_rows, T::zero());
+        }
+        if self.loss_weights.len() != n_rows {
+            self.loss_weights.resize(n_rows, T::zero());
         }
     }
 }
@@ -146,11 +151,53 @@ where
             return false;
         }
 
-        let loss = options.loss.loss(
-            &evaluator.yhat,
-            dataset.y.as_slice().unwrap(),
-            dataset.weights.as_ref().and_then(|w| w.as_slice()),
-        );
+        let max_delay = node_utils::max_delay(&self.expr.nodes);
+        let loss = if max_delay == 0 {
+            options
+                .loss
+                .loss(&evaluator.yhat, dataset.y.as_slice().unwrap(), dataset.weights_slice())
+        } else if dataset.sequence_ids.is_none() {
+            let valid_start = max_delay.min(dataset.n_rows);
+            if valid_start >= dataset.n_rows {
+                self.loss = T::infinity();
+                self.cost = T::infinity();
+                return false;
+            }
+            let weights = dataset
+                .weights
+                .as_ref()
+                .and_then(|w| w.as_slice())
+                .map(|w| &w[valid_start..]);
+            options.loss.loss(
+                &evaluator.yhat[valid_start..],
+                &dataset.y.as_slice().unwrap()[valid_start..],
+                weights,
+            )
+        } else {
+            if !dataset.has_valid_delay_rows(max_delay) {
+                self.loss = T::infinity();
+                self.cost = T::infinity();
+                return false;
+            }
+            let validity = dynamic_expressions::delay_validity_mask(
+                &self.expr.nodes,
+                dataset.n_rows,
+                dataset.sequence_ids_slice(),
+            );
+            let base_weights = dataset.weights_slice();
+            for (row, valid) in validity.into_iter().enumerate() {
+                evaluator.loss_weights[row] = if valid {
+                    base_weights.map_or_else(T::one, |w| w[row])
+                } else {
+                    T::zero()
+                };
+            }
+            options.loss.loss(
+                &evaluator.yhat,
+                dataset.y.as_slice().unwrap(),
+                Some(&evaluator.loss_weights),
+            )
+        };
         if loss.is_nan() {
             self.loss = loss;
             self.cost = T::nan();

--- a/symbolic_regression/src/search_utils.rs
+++ b/symbolic_regression/src/search_utils.rs
@@ -137,6 +137,8 @@ where
     T: Float + AddAssign + num_traits::FromPrimitive + num_traits::ToPrimitive + Display + Send + Sync,
     Ops: dynamic_expressions::OperatorSet<T = T> + Send + Sync,
 {
+    validate_delay_options(options);
+
     let baseline_loss = if options.use_baseline {
         baseline_loss_from_zero_expression::<T, Ops, D>(dataset, options.loss.as_ref())
     } else {
@@ -388,6 +390,8 @@ where
     Ops: dynamic_expressions::OperatorSet<T = T>,
 {
     pub fn new(dataset: Dataset<T>, options: Options<T, D>) -> Self {
+        validate_delay_options(&options);
+
         let baseline_loss = if options.use_baseline {
             baseline_loss_from_zero_expression::<T, Ops, D>(&dataset, options.loss.as_ref())
         } else {
@@ -492,6 +496,14 @@ where
             hall_of_fame: hall,
             best: pools.best,
         }
+    }
+}
+
+fn validate_delay_options<T: Float, const D: usize>(options: &Options<T, D>) {
+    if options.max_delay > 0 && options.batching {
+        panic!(
+            "delay expressions require ordered rows, but batching samples random rows; disable batching or add contiguous sequence-aware batching"
+        );
     }
 }
 
@@ -662,6 +674,7 @@ where
                 dataset.n_features,
                 nlength,
                 options.maxsize,
+                options,
             );
             let mut m = PopMember::from_expr(expr, dataset.n_features, options);
             let _ = m.evaluate(&full_dataset, options, &mut evaluator);
@@ -818,5 +831,34 @@ mod batching_search_tests {
 
         let pop_state = engine.core.pools.pops[0].as_ref().expect("pop exists");
         assert!(pop_state.batch_dataset.is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "delay expressions require ordered rows")]
+    fn delay_rejects_random_row_batching() {
+        type T = f64;
+        type Ops = BuiltinOpsF64;
+        const D: usize = 3;
+
+        let n_rows = 20;
+        let n_features = 1;
+        let x = Array2::<T>::zeros((n_features, n_rows));
+        let y = Array1::zeros(n_rows);
+        let dataset = Dataset::new(x, y);
+
+        let operators = Ops::from_names::<D, _>(["+", "*"]).expect("valid opset");
+        let options: Options<T, D> = Options {
+            operators,
+            batching: true,
+            max_delay: 3,
+            niterations: 1,
+            ncycles_per_iteration: 1,
+            populations: 1,
+            population_size: 6,
+            progress: false,
+            ..Default::default()
+        };
+
+        let _ = SearchEngine::<T, Ops, D>::new(dataset, options);
     }
 }

--- a/symbolic_regression/src/tests/mod.rs
+++ b/symbolic_regression/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod test_compress_constants;
 mod test_constant_optimization_birth_reset;
 mod test_cost_normalization;
 mod test_count_depth_proptests;
+mod test_delay_warmup;
 mod test_early_stop;
 mod test_equation_search_runs;
 mod test_frequency_in_tournament;

--- a/symbolic_regression/src/tests/test_count_depth_proptests.rs
+++ b/symbolic_regression/src/tests/test_count_depth_proptests.rs
@@ -8,6 +8,7 @@ use proptest::prelude::*;
 use super::common::{D, T, TestOps};
 use crate::mutation_functions::prepend_random_op_in_place;
 use crate::operator_library::OperatorLibrary;
+use crate::options::Options;
 
 const N_FEATURES: usize = 5;
 const N_CONSTS: usize = 3;
@@ -37,8 +38,9 @@ proptest! {
         let before = node_utils::count_depth(&expr.nodes);
 
         let ops = OperatorLibrary::sr_default::<TestOps, D>();
+        let options = Options::<T, D>::default();
         let mut rng = Rng::with_seed(rng_seed);
-        prop_assert!(prepend_random_op_in_place(&mut rng, &mut expr, &ops, N_FEATURES));
+        prop_assert!(prepend_random_op_in_place(&mut rng, &mut expr, &ops, N_FEATURES, &options));
 
         let after = node_utils::count_depth(&expr.nodes);
         prop_assert_eq!(after, before + 1);

--- a/symbolic_regression/src/tests/test_delay_warmup.rs
+++ b/symbolic_regression/src/tests/test_delay_warmup.rs
@@ -1,0 +1,66 @@
+use dynamic_expressions::expression::{Metadata, PostfixExpr};
+use dynamic_expressions::node::PNode;
+use ndarray::{Array1, Array2};
+
+use super::common::{D, T, TestOps};
+use crate::dataset::TaggedDataset;
+use crate::pop_member::{Evaluator, PopMember};
+use crate::{Dataset, Options};
+
+#[test]
+fn delayed_expression_loss_ignores_unavailable_warmup_rows() {
+    let x = Array2::from_shape_vec((1, 5), vec![10.0 as T, 20.0, 30.0, 40.0, 50.0]).unwrap();
+    let y = Array1::from_vec(vec![999.0 as T, 999.0, 10.0, 20.0, 30.0]);
+    let dataset = Dataset::with_weights_and_names(x, y, None, vec!["x".into()]);
+    let tagged = TaggedDataset::new(&dataset, None);
+    let expr = PostfixExpr::<T, TestOps, D>::new(
+        vec![PNode::Delay { feature: 0, offset: 2 }],
+        Vec::new(),
+        Metadata {
+            variable_names: vec!["x".into()],
+        },
+    );
+    let options = Options::<T, D> {
+        max_delay: 2,
+        progress: false,
+        ..Default::default()
+    };
+    let mut member = PopMember::from_expr(expr, dataset.n_features, &options);
+    let mut evaluator = Evaluator::new(dataset.n_rows);
+
+    assert!(member.evaluate(&tagged, &options, &mut evaluator));
+    assert_eq!(member.loss, 0.0);
+}
+
+#[test]
+fn delayed_expression_loss_respects_sequence_boundaries() {
+    let x = Array2::from_shape_vec((1, 6), vec![10.0 as T, 20.0, 30.0, 100.0, 200.0, 300.0]).unwrap();
+    let y = Array1::from_vec(vec![999.0 as T, 10.0, 20.0, 999.0, 100.0, 200.0]);
+    let dataset = Dataset::with_weights_names_and_sequence_ids(x, y, None, vec!["x".into()], vec![0, 0, 0, 1, 1, 1]);
+    let tagged = TaggedDataset::new(&dataset, None);
+    let expr = PostfixExpr::<T, TestOps, D>::new(
+        vec![PNode::Delay { feature: 0, offset: 1 }],
+        Vec::new(),
+        Metadata {
+            variable_names: vec!["x".into()],
+        },
+    );
+    let options = Options::<T, D> {
+        max_delay: 1,
+        progress: false,
+        ..Default::default()
+    };
+    let mut member = PopMember::from_expr(expr, dataset.n_features, &options);
+    let mut evaluator = Evaluator::new(dataset.n_rows);
+
+    assert!(member.evaluate(&tagged, &options, &mut evaluator));
+    assert_eq!(member.loss, 0.0);
+}
+
+#[test]
+#[should_panic(expected = "sequence_ids must be nondecreasing")]
+fn sequence_ids_must_be_contiguous() {
+    let x = Array2::from_shape_vec((1, 3), vec![1.0 as T, 2.0, 3.0]).unwrap();
+    let y = Array1::from_vec(vec![0.0 as T, 0.0, 0.0]);
+    let _ = Dataset::with_weights_names_and_sequence_ids(x, y, None, vec!["x".into()], vec![0, 1, 0]);
+}

--- a/symbolic_regression/src/tests/test_mutation_regressions.rs
+++ b/symbolic_regression/src/tests/test_mutation_regressions.rs
@@ -32,6 +32,7 @@ fn randomize_mutation_can_succeed_below_size_3() {
     options.use_frequency = false;
     options.mutation_weights = MutationWeights {
         mutate_constant: 0.0,
+        mutate_delay_offset: 0.0,
         mutate_operator: 0.0,
         mutate_feature: 0.0,
         swap_operands: 0.0,
@@ -156,6 +157,7 @@ fn add_node_includes_append_at_leaf_move() {
     options.use_frequency = false;
     options.mutation_weights = MutationWeights {
         mutate_constant: 0.0,
+        mutate_delay_offset: 0.0,
         mutate_operator: 0.0,
         mutate_feature: 0.0,
         swap_operands: 0.0,
@@ -251,6 +253,7 @@ fn mutate_operator_can_be_a_noop_and_still_succeeds() {
     options.use_frequency = false;
     options.mutation_weights = MutationWeights {
         mutate_constant: 0.0,
+        mutate_delay_offset: 0.0,
         mutate_operator: 1.0,
         mutate_feature: 0.0,
         swap_operands: 0.0,

--- a/symbolic_regression/src/tests/test_next_generation_retry_and_skip.rs
+++ b/symbolic_regression/src/tests/test_next_generation_retry_and_skip.rs
@@ -24,6 +24,7 @@ fn next_generation_fails_constraints_after_retries() {
 
     let weights = MutationWeights {
         mutate_constant: 0.0,
+        mutate_delay_offset: 0.0,
         mutate_operator: 0.0,
         mutate_feature: 0.0,
         swap_operands: 0.0,
@@ -89,6 +90,7 @@ fn reg_evol_cycle_skips_replacement_when_configured() {
     );
     let weights = MutationWeights {
         mutate_constant: 0.0,
+        mutate_delay_offset: 0.0,
         mutate_operator: 0.0,
         mutate_feature: 0.0,
         swap_operands: 0.0,

--- a/symbolic_regression/src/tests/test_rotate_tree_proptests.rs
+++ b/symbolic_regression/src/tests/test_rotate_tree_proptests.rs
@@ -123,12 +123,14 @@ fn node_multiset(nodes: &[PNode]) -> BTreeMap<(u8, u16, u16), usize> {
     // - Var:   (0, feature, 0)
     // - Const: (1, idx, 0)
     // - Op:    (2, arity, op)
+    // - Delay: (3, feature, offset)
     let mut m: BTreeMap<(u8, u16, u16), usize> = BTreeMap::new();
     for n in nodes {
         let k = match *n {
             PNode::Var { feature } => (0, feature, 0),
             PNode::Const { idx } => (1, idx, 0),
             PNode::Op { arity, op } => (2, arity as u16, op),
+            PNode::Delay { feature, offset } => (3, feature, offset),
         };
         *m.entry(k).or_insert(0) += 1;
     }

--- a/symbolic_regression/tests/test_custom_operator_search.rs
+++ b/symbolic_regression/tests/test_custom_operator_search.rs
@@ -22,6 +22,7 @@ fn custom_operator_is_used_in_end_to_end_search() {
 
     let mutation_weights = MutationWeights {
         mutate_constant: 0.0,
+        mutate_delay_offset: 0.0,
         mutate_operator: 0.0,
         mutate_feature: 0.0,
         swap_operands: 0.0,

--- a/symbolic_regression/tests/test_delay_source.rs
+++ b/symbolic_regression/tests/test_delay_source.rs
@@ -1,0 +1,117 @@
+use dynamic_expressions::StringTreeOptions;
+use dynamic_expressions::expression::{Metadata, PostfixExpr};
+use dynamic_expressions::node::PNode;
+use ndarray::{Array1, Array2};
+use symbolic_regression::prelude::*;
+use symbolic_regression::{Dataset, Options, equation_search};
+
+#[test]
+fn delay_leaf_evaluates_shifted_feature_without_expanded_columns() {
+    let x = Array2::from_shape_vec((1, 5), vec![10.0f64, 20.0, 30.0, 40.0, 50.0]).unwrap();
+    let expr = PostfixExpr::<f64, BuiltinOpsF64, 2>::new(
+        vec![PNode::Delay { feature: 0, offset: 2 }],
+        Vec::new(),
+        Metadata {
+            variable_names: vec!["x".into()],
+        },
+    );
+
+    let (out, complete) = eval_tree_array::<f64, BuiltinOpsF64, 2>(&expr, x.view(), &EvalOptions::default());
+
+    assert!(complete);
+    assert_eq!(out, vec![10.0, 10.0, 10.0, 20.0, 30.0]);
+    assert_eq!(
+        string_tree(
+            &expr,
+            StringTreeOptions {
+                variable_names: Some(&["x".to_string()]),
+                ..Default::default()
+            },
+        ),
+        "delay(x, 2)"
+    );
+}
+
+#[test]
+fn delay_validity_mask_reports_warmup_and_sequence_boundaries() {
+    let expr = PostfixExpr::<f64, BuiltinOpsF64, 2>::new(
+        vec![PNode::Delay { feature: 0, offset: 2 }],
+        Vec::new(),
+        Metadata::default(),
+    );
+
+    assert_eq!(
+        dynamic_expressions::delay_validity_mask(&expr.nodes, 6, None),
+        vec![false, false, true, true, true, true]
+    );
+    assert_eq!(
+        dynamic_expressions::delay_validity_mask(&expr.nodes, 6, Some(&[0, 0, 0, 1, 1, 1])),
+        vec![false, false, true, false, false, true]
+    );
+}
+
+#[test]
+fn search_can_use_delay_leaf_without_lag_expanded_inputs() {
+    const D: usize = 3;
+    let n_rows = 96usize;
+    let mut x_values = Vec::with_capacity(n_rows);
+    for i in 0..n_rows {
+        x_values.push(((i as f64) / 7.0).sin());
+    }
+
+    let x = Array2::from_shape_vec((1, n_rows), x_values.clone()).unwrap();
+    let mut y = Array1::<f64>::zeros(n_rows);
+    for row in 0..n_rows {
+        y[row] = x_values[row.saturating_sub(3)];
+    }
+    let dataset = Dataset::with_weights_and_names(x, y, None, vec!["x".into()]);
+
+    let options = Options::<f64, D> {
+        seed: 2,
+        niterations: 25,
+        populations: 4,
+        population_size: 64,
+        ncycles_per_iteration: 300,
+        maxsize: 5,
+        maxdepth: 3,
+        max_delay: 4,
+        delay_probability: 0.7,
+        should_optimize_constants: false,
+        progress: false,
+        operators: BuiltinOpsF64::from_names(["+", "sub", "*"]).unwrap(),
+        ..Default::default()
+    };
+
+    let result = equation_search::<f64, BuiltinOpsF64, D>(&dataset, &options);
+    let expr = string_tree(
+        &result.best.expr,
+        StringTreeOptions {
+            variable_names: Some(&["x".to_string()]),
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        expr.contains("delay(x, 3)") || result.best.loss < 1e-8,
+        "best expression {expr:?} had loss {}",
+        result.best.loss
+    );
+}
+
+#[test]
+fn delay_complexity_counts_variable_operation_and_offset() {
+    let expr = PostfixExpr::<f64, BuiltinOpsF64, 2>::new(
+        vec![PNode::Delay { feature: 0, offset: 3 }],
+        Vec::new(),
+        Metadata::default(),
+    );
+    let options = Options::<f64, 2> {
+        complexity_of_variables: 1,
+        complexity_of_delay: 1,
+        complexity_of_delay_offset: 1,
+        variable_complexities: Some(vec![1]),
+        ..Default::default()
+    };
+
+    assert_eq!(symbolic_regression::compute_complexity(&expr.nodes, &options), 3);
+}


### PR DESCRIPTION
## Summary

Adds native delayed feature leaves to the expression/search stack:

- `PNode::Delay { feature, offset }`, formatted as `delay(x, k)`
- shifted feature evaluation without lag-expanded input columns
- delay creation and offset mutation behind opt-in options
- delay complexity costs for the operation and offset parameter
- delay-aware loss masking for warmup rows and sequence boundaries
- optional nondecreasing per-row `sequence_ids` on `Dataset`
- validity-mask helpers for standalone expression evaluation
- focused tests and a local benchmark example

## Semantics

Delay search is disabled by default. It activates when `max_delay > 0` and `delay_probability > 0.0`.

Rows whose delayed source is unavailable are excluded from loss. For one contiguous sequence, this drops the first `max(delay offset)` rows. With `sequence_ids`, rows are valid only when the delayed source row is in the same contiguous sequence.

Random row batching is rejected when delay is enabled because it destroys row order. A future change could add contiguous, sequence-aware batching.

## Validation

- `cargo fmt`
- `cargo test -p symbolic_regression --release`
- `cargo build -p symbolic_regression --example delay_benchmark --release`
- `git diff --check`
- short native-delay benchmark smoke run
